### PR TITLE
Make sourcemaps more resilient against out-of-range modifications

### DIFF
--- a/.gitpod.setup.sh
+++ b/.gitpod.setup.sh
@@ -9,4 +9,5 @@ git clone https://github.com/bcmi-labs/arduino-editor
 cd arduino-editor
 yarn
 
-echo "start an Arduino IDE with: yarn --cwd /workspace/arduino-editor/browser-app start"
+echo "starting an Arduino IDE with: yarn --cwd /workspace/arduino-editor/browser-app start"
+yarn --cwd /workspace/arduino-editor/browser-app start


### PR DESCRIPTION
I was not able to reproduce the issue per se. Yet, the code in question was not tolerant against out-of-range access which is what likely caused the issue at hand.

This PR makes source maps more out-of-range tolerant and compliant with the the LSP spec.

Fixes bcmi-labs/arduino-language-server#6