### PR TITLE
Build on latest Xcode to avoid sining issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         ExecutableSuffix: ''
       mac:
-        imageName: 'macos-10.14'
+        imageName: 'macOS-latest'
         ExecutableSuffix: ''
       windows:
         imageName: 'vs2017-win2016'


### PR DESCRIPTION
Otherwise, the Pro IDE signing fails with:
`The binary uses an SDK older than the 10.9 SDK.`

Signed-off-by: Akos Kitta <kittaakos@typefox.io>