### PR TITLE
Generalized 'No such file or directory handling'

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -360,13 +360,13 @@ func (handler *InoHandler) handleError(ctx context.Context, err error) error {
 			return err
 		}
 	} else if strings.Contains(errorStr, "No such file or directory") {
-		exp, regexpErr := regexp.Compile("([\\w\\.\\-]+)\\.h: No such file or directory")
+		exp, regexpErr := regexp.Compile("([\\w\\.\\-]+): No such file or directory")
 		if regexpErr != nil {
 			panic(regexpErr)
 		}
 		submatch := exp.FindStringSubmatch(errorStr)
-		message = "Editor support may be inaccurate because the header `" + submatch[1] + ".h` was not found."
-		message += " If it is part of a library, use the Library Manager to install it"
+		message = "Editor support may be inaccurate because the header `" + submatch[1] + "` was not found."
+		message += " If it is part of a library, use the Library Manager to install it."
 	} else {
 		message = "Could not start editor support.\n" + errorStr
 	}


### PR DESCRIPTION
- Removed the `.h` literally match from the regexp.
- Let the submatch handle the `.h` suffix.

To handle both types of error messages:
 - `Alma.h: No such file or directory` and
 - `chrono: No such file or directory`.

----

Examples:
```cpp
#include "Alma.h"
void setup() { }
void loop() { }
```
![Screen Shot 2020-07-28 at 18 31 47](https://user-images.githubusercontent.com/1405703/88694299-a237ea00-d100-11ea-8dc9-12bbbe6ac5da.jpg)

```cpp
#include <chrono>
void setup() { }
void loop() { }
```
![Screen Shot 2020-07-28 at 18 33 39](https://user-images.githubusercontent.com/1405703/88694477-e4612b80-d100-11ea-97d7-d4bdee9c6294.jpg)



Closes #30.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>