### PR TITLE
Add GitHub Actions workflow to repackage clangd from LLVM releases

### DIFF
--- a/.github/workflows/repackage-clangd.yml
+++ b/.github/workflows/repackage-clangd.yml
@@ -9,6 +9,12 @@ on:
   push:
     paths:
       - .github/workflows/repackage-clangd.yml
+  workflow_dispatch:
+    inputs:
+      llvm-version:
+        description: LLVM version (x.y.z)
+        required: true
+        default: latest
 
 env:
   # The LLVM repository's tags use the form llvmorg-<VERSION>
@@ -52,9 +58,15 @@ jobs:
       - name: Determine version of the latest LLVM release
         id: get-llvm-release-version
         run: |
-          LLVM_TAG_NAME="${{ fromJson(steps.get-llvm-release-data.outputs.data).tag_name }}"
-          # Extract the version number substring from the tag name
-          LLVM_RELEASE_VERSION="${LLVM_TAG_NAME#${{ env.LLVM_TAG_PREFIX }}}"
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ github.event.inputs.llvm-version }}" == "latest" ]]; then
+            LLVM_TAG_NAME="${{ fromJson(steps.get-llvm-release-data.outputs.data).tag_name }}"
+            # Extract the version number substring from the tag name
+            LLVM_RELEASE_VERSION="${LLVM_TAG_NAME#${{ env.LLVM_TAG_PREFIX }}}"
+            echo "Latest LLVM version: $LLVM_RELEASE_VERSION"
+          else
+            LLVM_RELEASE_VERSION="${{ github.event.inputs.llvm-version }}"
+            echo "Using selected LLVM version: $LLVM_RELEASE_VERSION"
+          fi
           echo "::set-output name=llvm-release-version::$LLVM_RELEASE_VERSION"
 
       - name: Check if clangd from the latest LLVM release already exists on the server


### PR DESCRIPTION
The workflow runs daily and checks if there is an [LLVM release](https://github.com/llvm/llvm-project/releases) available that isn't already present on Arduino's servers and that provides pre-built binaries for all required targets (Linux, Linux ARM, Linux ARM 64 bit, Windows, macOS).

If so, the LLVM pre-builds are downloaded and clangd, along with its dependencies, are extracted, repackaged, and uploaded to Arduino's server.

---
The workflow is configured to trigger on the [`workflow_dispatch` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch). This provides an input to allow selection of an arbitrary LLVM version to use as a source for repackaging clangd:

![Clipboard01](https://user-images.githubusercontent.com/8572152/89699887-2b100c00-d8df-11ea-8221-4ff244b3653a.png)

---
NOTE: [Arduino's existing clangd repackage of 9.0.0 for Linux](https://downloads.arduino.cc/arduino-language-server/clangd/clangd_9.0.0_linux.zip) contains the files `lib/libtinfo.so.5` and `lib/libtinfo.so.5.9`, but these files are not present in the [LLVM 9.0.0 release](https://releases.llvm.org/download.html#9.0.0). So, although the workflow adds all the other shared library files to match the structure of the previous manual repackages I used as a reference, it does not add these two files.