### PR TITLE
Manual builds must not publish when not on master.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
   publish:
     needs: build
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     steps:
       - name: Download Workflow Artifact [GitHub Actions]


### PR DESCRIPTION
Only CRON job and `workflow_dispatch` from the `master` should publish
a new nightly to AWS.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>


----

@per1234, I made this PR to avoid publishing a nightly from a random branch when starting the workflow manually. What do you think? Does it have value?  Thanks!