### PR TITLE
Force sketch rebuild check if "undeclared_var_use" error is detected

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1182,7 +1182,7 @@ func (handler *InoHandler) FromClangd(ctx context.Context, connection *jsonrpc2.
 				inoDocsWithDiagnostics[inoDiag.URI] = true
 				cleanUpInoDiagnostics = true
 				for _, diag := range inoDiag.Diagnostics {
-					if diag.Code == "undeclared_var_use_suggest" {
+					if diag.Code == "undeclared_var_use_suggest" || diag.Code == "undeclared_var_use" {
 						handler.buildSketchSymbolsCheck = true
 					}
 				}


### PR DESCRIPTION
before it triggered only for 'undeclared_var_use_suggest'.