### PR TITLE
Introducing progress-message handler

### DIFF
--- a/handler/progress.go
+++ b/handler/progress.go
@@ -1,0 +1,192 @@
+package handler
+
+import (
+	"context"
+	"log"
+	"sync"
+
+	"github.com/bcmi-labs/arduino-language-server/lsp"
+	"github.com/bcmi-labs/arduino-language-server/streams"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type ProgressProxyHandler struct {
+	conn               *jsonrpc2.Conn
+	mux                sync.Mutex
+	actionRequiredCond *sync.Cond
+	proxies            map[string]*progressProxy
+}
+
+type progressProxyStatus int
+
+const (
+	progressProxyNew progressProxyStatus = iota
+	progressProxyCreated
+	progressProxyBegin
+	progressProxyReport
+	progressProxyEnd
+)
+
+type progressProxy struct {
+	currentStatus  progressProxyStatus
+	requiredStatus progressProxyStatus
+	beginReq       *lsp.WorkDoneProgressBegin
+	reportReq      *lsp.WorkDoneProgressReport
+	endReq         *lsp.WorkDoneProgressEnd
+}
+
+func NewProgressProxy(conn *jsonrpc2.Conn) *ProgressProxyHandler {
+	res := &ProgressProxyHandler{
+		conn:    conn,
+		proxies: map[string]*progressProxy{},
+	}
+	res.actionRequiredCond = sync.NewCond(&res.mux)
+	go res.handlerLoop()
+	return res
+}
+
+func (p *ProgressProxyHandler) handlerLoop() {
+	defer streams.CatchAndLogPanic()
+
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	for {
+		p.actionRequiredCond.Wait()
+
+		for id, proxy := range p.proxies {
+			for proxy.currentStatus != proxy.requiredStatus {
+				p.handleProxy(id, proxy)
+			}
+		}
+
+		// Cleanup ended proxies
+		for id, proxy := range p.proxies {
+			if proxy.currentStatus == progressProxyEnd {
+				delete(p.proxies, id)
+			}
+		}
+	}
+}
+
+func (p *ProgressProxyHandler) handleProxy(id string, proxy *progressProxy) {
+	ctx := context.Background()
+	switch proxy.currentStatus {
+	case progressProxyNew:
+		p.mux.Unlock()
+		var res lsp.WorkDoneProgressCreateResult
+		err := p.conn.Call(ctx, "window/workDoneProgress/create", &lsp.WorkDoneProgressCreateParams{Token: id}, &res)
+		p.mux.Lock()
+
+		if err != nil {
+			log.Printf("ProgressHandler: error creating token %s: %v", id, err)
+		} else {
+			proxy.currentStatus = progressProxyCreated
+		}
+
+	case progressProxyCreated:
+		p.mux.Unlock()
+		err := p.conn.Notify(ctx, "$/progress", lsp.ProgressParams{
+			Token: id,
+			Value: lsp.Raw(proxy.beginReq),
+		})
+		p.mux.Lock()
+
+		proxy.beginReq = nil
+		if err != nil {
+			log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+		} else {
+			proxy.currentStatus = progressProxyBegin
+		}
+
+	case progressProxyBegin:
+		if proxy.requiredStatus == progressProxyReport {
+			p.mux.Unlock()
+			err := p.conn.Notify(ctx, "$/progress", &lsp.ProgressParams{
+				Token: id,
+				Value: lsp.Raw(proxy.reportReq)})
+			p.mux.Lock()
+
+			proxy.reportReq = nil
+			if err != nil {
+				log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+			} else {
+				proxy.requiredStatus = progressProxyBegin
+			}
+
+		} else if proxy.requiredStatus == progressProxyEnd {
+			p.mux.Unlock()
+			err := p.conn.Notify(ctx, "$/progress", &lsp.ProgressParams{
+				Token: id,
+				Value: lsp.Raw(proxy.endReq),
+			})
+			p.mux.Lock()
+
+			proxy.endReq = nil
+			if err != nil {
+				log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+			} else {
+				proxy.currentStatus = progressProxyEnd
+			}
+
+		}
+	}
+}
+
+func (p *ProgressProxyHandler) Create(id string) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if _, opened := p.proxies[id]; opened {
+		// Already created
+		return
+	}
+
+	p.proxies[id] = &progressProxy{
+		currentStatus:  progressProxyNew,
+		requiredStatus: progressProxyCreated,
+	}
+	p.actionRequiredCond.Broadcast()
+}
+
+func (p *ProgressProxyHandler) Begin(id string, req *lsp.WorkDoneProgressBegin) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	proxy, ok := p.proxies[id]
+	if !ok {
+		return
+	}
+
+	proxy.beginReq = req
+	proxy.requiredStatus = progressProxyBegin
+	p.actionRequiredCond.Broadcast()
+}
+
+func (p *ProgressProxyHandler) Report(id string, req *lsp.WorkDoneProgressReport) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	proxy, ok := p.proxies[id]
+	if !ok {
+		return
+	}
+
+	proxy.reportReq = req
+	proxy.requiredStatus = progressProxyReport
+	p.actionRequiredCond.Broadcast()
+}
+
+func (p *ProgressProxyHandler) End(id string, req *lsp.WorkDoneProgressEnd) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	proxy, ok := p.proxies[id]
+	if !ok {
+		return
+	}
+
+	proxy.endReq = req
+	proxy.requiredStatus = progressProxyEnd
+	p.actionRequiredCond.Broadcast()
+}

--- a/handler/syncer.go
+++ b/handler/syncer.go
@@ -15,7 +15,7 @@ type AsyncHandler struct {
 func (ah AsyncHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
 	switch req.Method {
 	case // Request that should not be parallelized
-		"$/progress":
+		"window/workDoneProgress/create", "$/progress":
 		ah.handler.Handle(ctx, conn, req)
 	default: // By default process all requests in parallel
 		go ah.handler.Handle(ctx, conn, req)

--- a/lsp/protocol_test.go
+++ b/lsp/protocol_test.go
@@ -68,13 +68,21 @@ func TestDocumentSymbolParse(t *testing.T) {
 func TestVariousMessages(t *testing.T) {
 	x := &ProgressParams{
 		Token: "token",
-		Value: WorkDoneProgressBegin{
+		Value: Raw(WorkDoneProgressBegin{
 			Title: "some work",
-		},
+		}),
 	}
 	data, err := json.Marshal(&x)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"token":"token", "value":{"kind":"begin","title":"some work"}}`, string(data))
+
+	var begin WorkDoneProgressBegin
+	err = json.Unmarshal([]byte(`{"kind":"begin","title":"some work"}`), &begin)
+	require.NoError(t, err)
+
+	var report WorkDoneProgressReport
+	err = json.Unmarshal([]byte(`{"kind":"report","message":"28/29","percentage":96.551724137931032}`), &report)
+	require.NoError(t, err)
 
 	msg := `{
 		"capabilities":{

--- a/lsp/service.go
+++ b/lsp/service.go
@@ -1058,8 +1058,8 @@ type SemanticHighlightingToken struct {
 }
 
 type ProgressParams struct {
-	Token string      `json:"token"`
-	Value interface{} `json:"value"`
+	Token string           `json:"token"`
+	Value *json.RawMessage `json:"value"`
 }
 
 type WorkDoneProgressCreateParams struct {
@@ -1088,6 +1088,15 @@ type WorkDoneProgressBegin struct {
 	Percentage  *int    `json:"percentage,omitempty"`
 }
 
+func Raw(v json.Marshaler) *json.RawMessage {
+	data, err := v.MarshalJSON()
+	if err != nil {
+		panic("error marshaling: " + err.Error())
+	}
+	dataRaw := json.RawMessage(data)
+	return &dataRaw
+}
+
 // MarshalJSON implements json.Marshaler.
 func (v WorkDoneProgressBegin) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
@@ -1102,8 +1111,11 @@ func (v WorkDoneProgressBegin) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaler.
 func (v *WorkDoneProgressBegin) UnmarshalJSON(data []byte) error {
 	type ProgressBegin struct {
-		WorkDoneProgressBegin
-		Kind string `json:"kind"`
+		Title       string  `json:"title"`
+		Cancellable *bool   `json:"cancellable,omitempty"`
+		Message     *string `json:"message,omitempty"`
+		Percentage  *int    `json:"percentage,omitempty"`
+		Kind        string  `json:"kind"`
 	}
 	var x ProgressBegin
 	if err := json.Unmarshal(data, &x); err != nil {
@@ -1112,31 +1124,36 @@ func (v *WorkDoneProgressBegin) UnmarshalJSON(data []byte) error {
 	if x.Kind != "begin" {
 		return errors.New(`expected kind == "begin"`)
 	}
-	*v = x.WorkDoneProgressBegin
+	(*v).Title = x.Title
+	(*v).Cancellable = x.Cancellable
+	(*v).Message = x.Message
+	(*v).Percentage = x.Percentage
 	return nil
 }
 
 type WorkDoneProgressReport struct {
-	Cancellable *bool   `json:"cancellable,omitempty"`
-	Message     *string `json:"message,omitempty"`
-	Percentage  *int    `json:"percentage,omitempty"`
+	Cancellable *bool    `json:"cancellable,omitempty"`
+	Message     *string  `json:"message,omitempty"`
+	Percentage  *float64 `json:"percentage,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
 func (v WorkDoneProgressReport) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Cancellable *bool   `json:"cancellable,omitempty"`
-		Message     *string `json:"message,omitempty"`
-		Percentage  *int    `json:"percentage,omitempty"`
-		Kind        string  `json:"kind"`
+		Cancellable *bool    `json:"cancellable,omitempty"`
+		Message     *string  `json:"message,omitempty"`
+		Percentage  *float64 `json:"percentage,omitempty"`
+		Kind        string   `json:"kind"`
 	}{v.Cancellable, v.Message, v.Percentage, "report"})
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (v *WorkDoneProgressReport) UnmarshalJSON(data []byte) error {
 	type ProgressReport struct {
-		WorkDoneProgressReport
-		Kind string `json:"kind"`
+		Cancellable *bool    `json:"cancellable,omitempty"`
+		Message     *string  `json:"message,omitempty"`
+		Percentage  *float64 `json:"percentage,omitempty"`
+		Kind        string   `json:"kind"`
 	}
 	var x ProgressReport
 	if err := json.Unmarshal(data, &x); err != nil {
@@ -1145,7 +1162,9 @@ func (v *WorkDoneProgressReport) UnmarshalJSON(data []byte) error {
 	if x.Kind != "report" {
 		return errors.New(`expected kind == "report"`)
 	}
-	*v = x.WorkDoneProgressReport
+	(*v).Cancellable = x.Cancellable
+	(*v).Message = x.Message
+	(*v).Percentage = x.Percentage
 	return nil
 }
 
@@ -1164,8 +1183,8 @@ func (v WorkDoneProgressEnd) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaler.
 func (v *WorkDoneProgressEnd) UnmarshalJSON(data []byte) error {
 	type ProgressEnd struct {
-		WorkDoneProgressEnd
-		Kind string `json:"kind"`
+		Message *string `json:"message,omitempty"`
+		Kind    string  `json:"kind"`
 	}
 	var x ProgressEnd
 	if err := json.Unmarshal(data, &x); err != nil {
@@ -1174,6 +1193,6 @@ func (v *WorkDoneProgressEnd) UnmarshalJSON(data []byte) error {
 	if x.Kind != "end" {
 		return errors.New(`expected kind == "end"`)
 	}
-	*v = x.WorkDoneProgressEnd
+	(*v).Message = x.Message
 	return nil
 }


### PR DESCRIPTION
The LS now caches progress message from clang and feed them to the IDE, eventually throttling to a sustainable pace.