### PR TITLE
Do not bail out if compile_commands.json is empty

### DIFF
--- a/handler/builder.go
+++ b/handler/builder.go
@@ -141,12 +141,12 @@ func (handler *InoHandler) generateBuildEnvironment() (*paths.Path, error) {
 		CompilerOut   string        `json:"compiler_out"`
 		CompilerErr   string        `json:"compiler_err"`
 		BuilderResult cmdBuilderRes `json:"builder_result"`
+		Success       bool          `json:"success"`
 	}
 	var res cmdRes
 	if err := json.Unmarshal(cmdOutput.Bytes(), &res); err != nil {
 		return nil, errors.Errorf("parsing arduino-cli output: %s", err)
 	}
-
 	// Return only the build path
 	log.Println("arduino-cli output:", cmdOutput)
 	return res.BuilderResult.BuildPath, nil

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -691,9 +691,7 @@ func examineCompileCommandsJSON(compileCommandsDir *paths.Path) map[string]bool 
 
 		compilers[compiler] = true
 	}
-	if len(compilers) == 0 {
-		panic("main compiler not found")
-	}
+
 	// Save back compile_commands.json with OS native file separator and extension
 	compileCommands.SaveToFile()
 


### PR DESCRIPTION
It may mean that the sketch can not be preprocessed because it contains too many errors. In this case, just keep it as-is and show the errors generated by clangd itself.