### PR TITLE
Fixed improper canonicalization on Windows

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -137,7 +137,7 @@ func NewInoHandler(stdio io.ReadWriteCloser, board lsp.Board) *InoHandler {
 		log.Fatalf("Could not create temp folder: %s", err)
 	} else {
 		handler.buildPath = buildPath.Canonical()
-		handler.buildSketchRoot = buildPath.Join("sketch").Canonical()
+		handler.buildSketchRoot = handler.buildPath.Join("sketch")
 	}
 
 	handler.progressHandler = NewProgressProxy(handler.StdioConn)
@@ -145,6 +145,7 @@ func NewInoHandler(stdio io.ReadWriteCloser, board lsp.Board) *InoHandler {
 	if enableLogging {
 		log.Println("Initial board configuration:", board)
 		log.Println("Language server build path:", handler.buildPath)
+		log.Println("Language server build sketch root:", handler.buildSketchRoot)
 	}
 
 	go handler.rebuildEnvironmentLoop()


### PR DESCRIPTION
It seems that if the path doesn't exist (as a file or directory) then it isn't correctly converted into the correct extended (non-8.3 DOS) form.

@rsora @silvanocerza this one probably requires an improvement in the go-paths-library to either:
- make `MkTempDir` return an already canonicalized form 
- make `Canonicalize` work correctly (don't know if this is possible...)
