### PR TITLE
Add security policy link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Qualities of an excellent report:
 - Be responsive. We may need you to provide additional information in order to investigate and resolve the issue.
 - If you find a solution to your problem, please comment on your issue report with an explanation of how you were able to fix it and close the issue.
 
+### Security
+
+If you think you found a vulnerability or other security-related bug in this project, please read our
+[security policy](https://github.com/arduino/arduino-language-server/security/policy) and report the bug to our Security Team 🛡️
+Thank you!
+
+e-mail contact: security@arduino.cc
+
 ## How to contribute
 
 Contributions are welcome! Here are all the ways you can contribute to the project.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Readme doesn't contain a link to the security policy.
* **What is the new behavior?**
<!-- if this is a feature change -->
Readme does contain a link to the security policy.