### PR TITLE
Add flag to set cli config file

### DIFF
--- a/handler/builder.go
+++ b/handler/builder.go
@@ -113,6 +113,7 @@ func (handler *InoHandler) generateBuildEnvironment(buildPath *paths.Path) error
 
 	// XXX: do this from IDE or via gRPC
 	args := []string{globalCliPath,
+		"--config-file", globalCliConfigPath,
 		"compile",
 		"--fqbn", fqbn,
 		"--only-compilation-database",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -29,13 +29,15 @@ import (
 )
 
 var globalCliPath string
+var globalCliConfigPath string
 var globalClangdPath string
 var globalFormatterConf *paths.Path
 var enableLogging bool
 
 // Setup initializes global variables.
-func Setup(cliPath string, clangdPath string, formatFilePath string, _enableLogging bool) {
+func Setup(cliPath, cliConfigPath, clangdPath, formatFilePath string, _enableLogging bool) {
 	globalCliPath = cliPath
+	globalCliConfigPath = cliConfigPath
 	globalClangdPath = clangdPath
 	if formatFilePath != "" {
 		globalFormatterConf = paths.New(formatFilePath)
@@ -632,6 +634,7 @@ func (handler *InoHandler) initializeWorkbench(ctx context.Context, params *lsp.
 func extractDataFolderFromArduinoCLI() (*paths.Path, error) {
 	// XXX: do this from IDE or via gRPC
 	args := []string{globalCliPath,
+		"--config-file", globalCliConfigPath,
 		"config",
 		"dump",
 		"--format", "json",

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 var clangdPath string
 var compileCommandsDir string
 var cliPath string
+var cliConfigPath string
 var initialFqbn string
 var initialBoardName string
 var enableLogging bool
@@ -26,6 +27,7 @@ func main() {
 	flag.StringVar(&clangdPath, "clangd", "clangd", "Path to clangd executable")
 	flag.StringVar(&compileCommandsDir, "compile-commands-dir", "", "Specify a path to look for compile_commands.json. If path is invalid, clangd will look in the current directory and parent paths of each source file. If not specified, the clangd process is started without the compilation database.")
 	flag.StringVar(&cliPath, "cli", "arduino-cli", "Path to arduino-cli executable")
+	flag.StringVar(&cliConfigPath, "cli-config", "", "Path to arduino-cli config file")
 	flag.StringVar(&initialFqbn, "fqbn", "arduino:avr:uno", "Fully qualified board name to use initially (can be changed via JSON-RPC)")
 	flag.StringVar(&initialBoardName, "board-name", "", "User-friendly board name to use initially (can be changed via JSON-RPC)")
 	flag.BoolVar(&enableLogging, "log", false, "Enable logging to files")
@@ -47,7 +49,11 @@ func main() {
 		log.SetOutput(os.Stderr)
 	}
 
-	handler.Setup(cliPath, clangdPath, formatFilePath, enableLogging)
+	if cliConfigPath == "" {
+		log.Fatal("Path to ArduinoCLI config file must be set.")
+	}
+
+	handler.Setup(cliPath, cliConfigPath, clangdPath, formatFilePath, enableLogging)
 	initialBoard := lsp.Board{Fqbn: initialFqbn, Name: initialBoardName}
 
 	stdio := streams.NewReadWriteCloser(os.Stdin, os.Stdout)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**

Adds a new flag.

- **What is the current behavior?**

When running the `arduino-cli` provided via the `--cli` flag the default config file is always used.

* **What is the new behavior?**

Now the `--cli-config` flag must be set to point to a config file so the `arduino-cli` will be run using that configuration.

* **Other information**:

None.

---
