### PR TITLE
Fix wrong textDocument/completion references

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1259,7 +1259,7 @@ func (handler *InoHandler) transformClangdResult(method string, inoURI, cppURI l
 			}
 		}
 		r.Items = newItems
-		log.Printf("<-- completion(%d items)", len(r.Items))
+		log.Printf("<-- completion(%d items) cppToIno=%v", len(r.Items), cppToIno)
 		return r
 
 	case *lsp.DocumentSymbolArrayOrSymbolInformationArray:

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -361,7 +361,6 @@ func (handler *InoHandler) HandleMessageFromIDE(ctx context.Context, conn *jsonr
 
 	case *lsp.CompletionParams:
 		// method: "textDocument/completion"
-		inoURI = p.TextDocument.URI
 		log.Printf("--> completion(%s:%d:%d)\n", p.TextDocument.URI, p.Position.Line, p.Position.Character)
 
 		if res, e := handler.ino2cppTextDocumentPositionParams(&p.TextDocumentPositionParams); e == nil {
@@ -370,6 +369,7 @@ func (handler *InoHandler) HandleMessageFromIDE(ctx context.Context, conn *jsonr
 		} else {
 			err = e
 		}
+		inoURI = p.TextDocument.URI
 
 	case *lsp.CodeActionParams:
 		// method "textDocument/codeAction"

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -391,7 +391,6 @@ func (handler *InoHandler) HandleMessageFromIDE(ctx context.Context, conn *jsonr
 
 	case *lsp.HoverParams:
 		// method: "textDocument/hover"
-		inoURI = p.TextDocument.URI
 		doc := &p.TextDocumentPositionParams
 		log.Printf("--> hover(%s:%d:%d)\n", doc.TextDocument.URI, doc.Position.Line, doc.Position.Character)
 
@@ -401,6 +400,7 @@ func (handler *InoHandler) HandleMessageFromIDE(ctx context.Context, conn *jsonr
 		} else {
 			err = e
 		}
+		inoURI = p.TextDocument.URI
 
 	case *lsp.DocumentSymbolParams:
 		// method "textDocument/documentSymbol"


### PR DESCRIPTION
The `textDocument/completion` response does not report the correct coordinates while working on a .ino file, this PR should fix the issue.