### PR TITLE
Bump Linux runner version for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             ExecutableSuffix: ''
             Exports: ''
           - os: macos-latest


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `ubuntu-16.04` runner is used for the Linux job used to build and test the application in the "build" GitHub Actions workflow. That runner has now been removed by GitHub:
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/
This causes the workflow runs to fail:
https://github.com/arduino/arduino-language-server/actions/runs/1268446237

>build (ubuntu-16.04)
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.

* **What is the new behavior?**
<!-- if this is a feature change -->
We will use the runner with the oldest version of Ubuntu that is now available as a GitHub-hosted runner: `ubuntu-18.04`.

The reason for using the oldest available Ubuntu version is to provide compatibility with the widest possible range of Linux versions for the users of the Arduino Language Server.
