### PR TITLE
Suppress 'anon_bitfield_qualifiers' errors

### DIFF
--- a/ls/lsp_client_clangd.go
+++ b/ls/lsp_client_clangd.go
@@ -22,6 +22,15 @@ type ClangdLSPClient struct {
 }
 
 func NewClangdLSPClient(logger jsonrpc.FunctionLogger, dataFolder *paths.Path, ls *INOLanguageServer) *ClangdLSPClient {
+	clangdConfFile := ls.buildPath.Join(".clangd")
+	clangdConf := fmt.Sprintln("Diagnostics:")
+	clangdConf += fmt.Sprintln("  Suppress: [anon_bitfield_qualifiers]")
+	clangdConf += fmt.Sprintln("CompileFlags:")
+	clangdConf += fmt.Sprintln("  Add: -ferror-limit=0")
+	if err := clangdConfFile.WriteFile([]byte(clangdConf)); err != nil {
+		logger.Logf("Error writing clangd configuration: %s", err)
+	}
+
 	// Start clangd
 	args := []string{
 		ls.config.ClangdPath.String(),

--- a/ls/lsp_client_clangd.go
+++ b/ls/lsp_client_clangd.go
@@ -38,7 +38,7 @@ func NewClangdLSPClient(logger jsonrpc.FunctionLogger, dataFolder *paths.Path, l
 		fmt.Sprintf(`--compile-commands-dir=%s`, ls.buildPath),
 	}
 	if dataFolder != nil {
-		args = append(args, fmt.Sprintf("-query-driver=%s", dataFolder.Join("packages", "**")))
+		args = append(args, fmt.Sprintf("-query-driver=%s", dataFolder.Join("packages", "**").Canonical()))
 	}
 
 	logger.Logf("    Starting clangd: %s", strings.Join(args, " "))


### PR DESCRIPTION
Those errors are present in the CMSIS-Atmel package, and makes the language server produce other bogus errors as a consquence of parse failure of header files.

See https://github.com/arduino/arduino-ide/issues/307
See https://github.com/arduino/arduino-ide/issues/112
