### PR TITLE
Send progress-end messages before shutting down

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -363,7 +363,13 @@ func (ls *INOLanguageServer) InitializeReqFromIDE(ctx context.Context, logger js
 }
 
 func (ls *INOLanguageServer) ShutdownReqFromIDE(ctx context.Context, logger jsonrpc.FunctionLogger) *jsonrpc.ResponseError {
+	done := make(chan bool)
+	go func() {
+		ls.progressHandler.Shutdown()
+		close(done)
+	}()
 	_, _ = ls.Clangd.conn.Shutdown(context.Background())
+	<-done
 	return nil
 }
 

--- a/ls/progress.go
+++ b/ls/progress.go
@@ -109,7 +109,7 @@ func (p *ProgressProxyHandler) handleProxy(id string, proxy *progressProxy) {
 
 			proxy.reportReq = nil
 			if err != nil {
-				log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+				log.Printf("ProgressHandler: error sending report req token %s: %v", id, err)
 			} else {
 				proxy.requiredStatus = progressProxyBegin
 			}
@@ -122,7 +122,7 @@ func (p *ProgressProxyHandler) handleProxy(id string, proxy *progressProxy) {
 
 			proxy.endReq = nil
 			if err != nil {
-				log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+				log.Printf("ProgressHandler: error sending end req token %s: %v", id, err)
 			} else {
 				proxy.currentStatus = progressProxyEnd
 			}
@@ -211,7 +211,7 @@ func (p *ProgressProxyHandler) Shutdown() {
 
 		proxy.endReq = nil
 		if err != nil {
-			log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+			log.Printf("ProgressHandler: error sending end req token %s: %v", id, err)
 		} else {
 			proxy.currentStatus = progressProxyEnd
 			proxy.requiredStatus = progressProxyEnd

--- a/ls/progress.go
+++ b/ls/progress.go
@@ -196,3 +196,27 @@ func (p *ProgressProxyHandler) End(id string, req *lsp.WorkDoneProgressEnd) {
 	proxy.requiredStatus = progressProxyEnd
 	p.actionRequiredCond.Broadcast()
 }
+
+func (p *ProgressProxyHandler) Shutdown() {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	for id, proxy := range p.proxies {
+		err := p.conn.Progress(&lsp.ProgressParams{
+			Token: lsp.EncodeMessage(id),
+			Value: lsp.EncodeMessage(&lsp.WorkDoneProgressEnd{
+				Message: "Shutdown",
+			}),
+		})
+
+		proxy.endReq = nil
+		if err != nil {
+			log.Printf("ProgressHandler: error sending begin req token %s: %v", id, err)
+		} else {
+			proxy.currentStatus = progressProxyEnd
+			proxy.requiredStatus = progressProxyEnd
+		}
+	}
+
+	p.actionRequiredCond.Broadcast()
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
This is required because the IDE does not correctly clean up resources once the language server is shutdown.

- **What is the current behavior?**
The language server shutdown without any further message.

* **What is the new behavior?**
The language server sends a progress-end for any pending progress channel open.
