### PR TITLE
Automatically detect the path of `clangd`, `arduino-cli`, and its configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The prerequisites to run the Arduino Language Server are:
 - [Arduino CLI](https://github.com/arduino/arduino-cli)
 - [clangd](https://github.com/clangd/clangd/releases)
 
-To start the language server the IDE must provide the path to Arduino CLI and clangd with the following flags in addition to the target board FQBN:
+To start the language server the IDE may provide the path to Arduino CLI and clangd with the following flags in addition to the target board FQBN:
 
 ```
 ./arduino-language-server \

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"os/user"
+	"path"
 
 	"github.com/arduino/arduino-language-server/ls"
 	"github.com/arduino/arduino-language-server/streams"
@@ -75,6 +77,15 @@ func main() {
 			log.Fatal("ArduinoCLI daemon address and instance number must be set.")
 		}
 	} else {
+		if *cliConfigPath == "" {
+			if user, _ := user.Current(); user != nil {
+				candidate := path.Join(user.HomeDir, ".arduino15/arduino-cli.yaml")
+				if _, err := os.Stat(candidate); err == nil {
+					*cliConfigPath = candidate
+					log.Printf("ArduinoCLI config file found at %s\n", candidate)
+				}
+			}
+		}
 		if *cliConfigPath == "" {
 			log.Fatal("Path to ArduinoCLI config file must be set.")
 		}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/exec"
 	"os/signal"
 
 	"github.com/arduino/arduino-language-server/ls"
@@ -68,15 +69,32 @@ func main() {
 		log.SetOutput(os.Stderr)
 	}
 
-	if *cliPath != "" {
+	if *cliDaemonAddress != "" || *cliDaemonInstanceNumber != -1 {
+		// if one is set, both must be set
+		if *cliDaemonAddress == "" || *cliDaemonInstanceNumber == -1 {
+			log.Fatal("ArduinoCLI daemon address and instance number must be set.")
+		}
+	} else {
 		if *cliConfigPath == "" {
 			log.Fatal("Path to ArduinoCLI config file must be set.")
 		}
-	} else if *cliDaemonAddress == "" || *cliDaemonInstanceNumber == -1 {
-		log.Fatal("ArduinoCLI daemon address and instance number must be set.")
+		if *cliPath == "" {
+			bin, _ := exec.LookPath("arduino-cli")
+			if bin == "" {
+				log.Fatal("Path to ArduinoCLI must be set.")
+			}
+			log.Printf("arduino-cli found at %s\n", bin)
+			*cliPath = bin
+		}
 	}
+
 	if *clangdPath == "" {
-		log.Fatal("Path to Clangd must be set.")
+		bin, _ := exec.LookPath("clangd")
+		if bin == "" {
+			log.Fatal("Path to Clangd must be set.")
+		}
+		log.Printf("clangd found at %s\n", bin)
+		*clangdPath = bin
 	}
 
 	config := &ls.Config{


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [X] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

Tests have not been added because I don't see any tests for command option handling in the existing code.

**What kind of change does this PR introduce?**
Better out-of-the-box configuration by default.

**What is the current behavior?**
`arduino-language-server` always requires providing full `arduino-cli` and `clangd` executable paths, and the `arduino-cli` configuration file path, even though these may vary across systems. This makes them difficult to include in project/editor configuration which is the same across systems.

**What is the new behavior?**
There should be no differences in behavior for successful runs.

Previously failing commands may now be successful if everything can be autodetected, along with printing a log message saying so.

Error messages will be different for failed runs when a configuration file is provided but `arduino-cli` could not be detected - previously it would ask for a daemon address, now it will ask for a path to `arduino-cli`.

**Other information**:
I've split the PR into separate commits for searching `$PATH` vs. finding the configuration file as they may have different issues to discuss. (Or if there is a better / more thorough way of finding the default configuration file I'm not aware of.)
