### PR TITLE
Added a short notice if the server is used interactively

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/arduino/arduino-cli v0.0.0-20220614161710-813cfe73a466
 	github.com/arduino/go-paths-helper v1.7.0
 	github.com/fatih/color v1.13.0
+	github.com/mattn/go-isatty v0.0.14
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.bug.st/json v1.15.6
@@ -28,7 +29,6 @@ require (
 	github.com/leonelquinteros/gotext v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/arduino/arduino-language-server/ls"
 	"github.com/arduino/arduino-language-server/streams"
 	"github.com/arduino/go-paths-helper"
+	"github.com/mattn/go-isatty"
 )
 
 func main() {
@@ -125,6 +127,16 @@ func main() {
 	}
 
 	inoHandler := ls.NewINOLanguageServer(stdio, stdio, config)
+
+	if isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()) {
+		fmt.Fprint(os.Stderr, `
+arduino-language-server is a language server that provides IDE-like features to editors.
+
+It should be used via an editor plugin rather than invoked directly. For more information, see:
+https://github.com/arduino/arduino-language-server/
+https://microsoft.github.io/language-server-protocol/
+`)
+	}
 
 	// Intercept kill signal
 	c := make(chan os.Signal, 2)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
If someone tries to start the language server interactively a warning is issued:

```
arduino-language-server is a language server that provides IDE-like features to editors.

It should be used via an editor plugin rather than invoked directly. For more information, see:
https://github.com/arduino/arduino-language-server/
https://microsoft.github.io/language-server-protocol/
```

**What is the current behavior?**
The language server starts without any visible output.

**What is the new behavior?**
The language server prints a warning.
