### PR TITLE
Implement a no-op `workspace/didChangeConfiguration` (#114)

### DIFF
--- a/ls/lsp_server_ide.go
+++ b/ls/lsp_server_ide.go
@@ -229,7 +229,14 @@ func (server *IDELSPServer) WorkspaceDidChangeWorkspaceFolders(logger jsonrpc.Fu
 }
 
 func (server *IDELSPServer) WorkspaceDidChangeConfiguration(logger jsonrpc.FunctionLogger, params *lsp.DidChangeConfigurationParams) {
-	panic("unimplemented")
+	// At least one LSP client, Eglot, sends this by default when
+	// first connecting, even if the otions are empty.
+	// https://github.com/joaotavora/eglot/blob/e835996e16610d0ded6d862214b3b452b8803ea8/eglot.el#L1080
+	//
+	// Since ALS doesn’t have any workspace configuration yet,
+	// ignore it.
+	return
+
 }
 
 func (server *IDELSPServer) WorkspaceDidChangeWatchedFiles(logger jsonrpc.FunctionLogger, params *lsp.DidChangeWatchedFilesParams) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [X] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Better client compatibility.

- **What is the current behavior?**
When connecting with default eglot settings, the server panics when eglot calls an unimplemented method.

* **What is the new behavior?**
It does not crash.
