### PR TITLE
Added flag to disable real-time PublishDiagnostics push

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -60,6 +60,7 @@ type Config struct {
 	FormatterConf                   *paths.Path
 	EnableLogging                   bool
 	SkipLibrariesDiscoveryOnRebuild bool
+	DisableRealTimeDiagnostics      bool
 }
 
 var yellow = color.New(color.FgHiYellow)
@@ -1191,6 +1192,11 @@ func (ls *INOLanguageServer) CopyFullBuildResults(logger jsonrpc.FunctionLogger,
 }
 
 func (ls *INOLanguageServer) PublishDiagnosticsNotifFromClangd(logger jsonrpc.FunctionLogger, clangParams *lsp.PublishDiagnosticsParams) {
+	if ls.config.DisableRealTimeDiagnostics {
+		logger.Logf("Ignored by configuration")
+		return
+	}
+
 	ls.readLock(logger, false)
 	defer ls.readUnlock(logger)
 

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ func main() {
 	skipLibrariesDiscoveryOnRebuild := flag.Bool(
 		"skip-libraries-discovery-on-rebuild", false,
 		"Skip libraries discovery on rebuild, it will make rebuilds faster but it will fail if the used libraries changes.")
+	noRealTimeDiagnostics := flag.Bool(
+		"no-real-time-diagnostics", false,
+		"Disable real time diagnostics")
 	flag.Parse()
 
 	if *loggingBasePath != "" {
@@ -123,6 +126,7 @@ func main() {
 		CliDaemonAddress:                *cliDaemonAddress,
 		CliInstanceNumber:               *cliDaemonInstanceNumber,
 		SkipLibrariesDiscoveryOnRebuild: *skipLibrariesDiscoveryOnRebuild,
+		DisableRealTimeDiagnostics:      *noRealTimeDiagnostics,
 	}
 
 	stdio := streams.NewReadWriteCloser(os.Stdin, os.Stdout)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
Add a flag to disable real-time diagnostics `-no-real-time-diagnostics`.
