### PR TITLE
Bump Windows runner version for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             ExecutableSuffix: ''
             Exports: 'CGO_ENABLED=1 MACOSX_DEPLOYMENT_TARGET=10.14 '
-          - os: windows-2016
+          - os: windows-2019
             ExecutableSuffix: '.exe'
             Exports: ''
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `windows-2016` runner is used for the Windows job used to build and test the application in the "build" GitHub Actions workflow. That runner has now been removed by GitHub. This causes the workflow runs to fail.
* **What is the new behavior?**
<!-- if this is a feature change -->
Previously, the `windows-2016` runner was used for the Windows job used to build and test the application in the build GitHub Actions workflow. That runner has now been removed by GitHub. In its place, we will use the runner with the oldest version of Windows that is now available as a GitHub-hosted runner: `windows-2019`.

The reason for using the oldest available Windows version is to provide compatibility with the widest possible range of Windows versions for the users of the Arduino Language Server.

---
