### PR TITLE
Add CI workflow to check the license file

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,0 +1,96 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
+name: Check License
+
+env:
+  EXPECTED_LICENSE_FILENAME: LICENSE.txt
+  # SPDX identifier: https://spdx.org/licenses/
+  EXPECTED_LICENSE_TYPE: Apache-2.0
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-license.ya?ml"
+      # See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
+  pull_request:
+    paths:
+      - ".github/workflows/check-license.ya?ml"
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 6 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
+  check-license:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
+
+      - name: Install licensee
+        run: gem install licensee
+
+      - name: Check license file
+        run: |
+          EXIT_STATUS=0
+          # See: https://github.com/licensee/licensee
+          LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
+
+          DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
+          echo "Detected license file: $DETECTED_LICENSE_FILE"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+            EXIT_STATUS=1
+          fi
+
+          DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
+          echo "Detected license type: $DETECTED_LICENSE_TYPE"
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${EXPECTED_LICENSE_TYPE}\""
+            EXIT_STATUS=1
+          fi
+
+          exit $EXIT_STATUS

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Check Taskfiles status](https://github.com/arduino/arduino-language-server/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/arduino-language-server/actions/workflows/check-taskfiles.yml)
 [![Check Go status](https://github.com/arduino/arduino-language-server/actions/workflows/check-go-task.yml/badge.svg)](https://github.com/arduino/arduino-language-server/actions/workflows/check-go-task.yml)
 [![Check Markdown status](https://github.com/arduino/arduino-language-server/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/arduino-language-server/actions/workflows/check-markdown-task.yml)
+[![Check License status](https://github.com/arduino/arduino-language-server/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/arduino-language-server/actions/workflows/check-license.yml)
 
 The **Arduino Language Server** is the tool that powers the autocompletion of the new [Arduino IDE 2][arduino-ide-repo]. It implements the standard [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) so it can be used with other IDEs as well.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure Enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
No checks are being made on [LICENSE.txt](https://github.com/arduino/arduino-language-server/blob/main/LICENSE.txt).
* **What is the new behavior?**
<!-- if this is a feature change -->
Whenever one of the recognized license file names are modified in the repository, the workflow runs [licensee](https://github.com/licensee/licensee) to check whether the license can be recognized and whether it is of the expected type.

GitHub has a useful [automated license detection system](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license) that determines the license type used by a repository, and surfaces that information in the repository home page, the search web interface, and the GitHub API. This license detection system requires that the license be defined by a dedicated file with one of several standardized filenames and paths.

GitHub's license detection system uses the popular licensee tool, so this file also serves to define the license type for any other usages of licensee, as well as to human readers of the file.

For this reason, and to ensure it remains a valid legal instrument, it's important that there be no non-standard modifications to the license file or collisions with other supported license files. This workflow ensures that any changes which would change the license type or which license file is used by the detection are caught automatically.

---
