### PR TITLE
Sync sketch formatter configuration from source

### DIFF
--- a/ls/ls_formatter.go
+++ b/ls/ls_formatter.go
@@ -12,17 +12,15 @@ func (ls *INOLanguageServer) createClangdFormatterConfig(logger jsonrpc.Function
 	// https://github.com/llvm/llvm-project/blob/64d06ed9c9e0389cd27545d2f6e20455a91d89b1/clang-tools-extra/clangd/ClangdLSPServer.cpp#L856-L868
 	// https://github.com/llvm/llvm-project/blob/64d06ed9c9e0389cd27545d2f6e20455a91d89b1/clang-tools-extra/clangd/ClangdServer.cpp#L402-L404
 
-	config := `# See: https://releases.llvm.org/11.0.1/tools/clang/docs/ClangFormatStyleOptions.html
+	config := `# Source: https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration
 ---
-Language: Cpp
-# LLVM is the default style setting, used when a configuration option is not set here
-BasedOnStyle: LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveBitFields: false
-AlignConsecutiveDeclarations: false
-AlignConsecutiveMacros: false
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
 AlignEscapedNewlines: DontAlign
 AlignOperands: Align
 AlignTrailingComments: true
@@ -33,16 +31,19 @@ AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: Always
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 AllowShortLambdasOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: No
+AttributeMacros:
+  - __capability
+BasedOnStyle: LLVM
 BinPackArguments: true
 BinPackParameters: true
-# Only used when "BreakBeforeBraces" set to "Custom"
+BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false
@@ -50,7 +51,7 @@ BraceWrapping:
   AfterEnum: false
   AfterFunction: false
   AfterNamespace: false
-  #AfterObjCDeclaration:
+  AfterObjCDeclaration: false
   AfterStruct: false
   AfterUnion: false
   AfterExternBlock: false
@@ -59,104 +60,148 @@ BraceWrapping:
   BeforeLambdaBody: false
   BeforeWhile: false
   IndentBraces: false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-  SplitEmptyNamespace: false
-# Java-specific
-#BreakAfterJavaFieldAnnotations:
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterJavaFieldAnnotations: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Attach
+BreakBeforeConceptDeclarations: false
+BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: false
 ColumnLimit: 0
-# "" matches none
-CommentPragmas: ""
+CommentPragmas: ''
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
 DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat: false
-# Docs say "Do not use this in config files". The default (LLVM 11.0.1) is "false".
-#ExperimentalAutoDetectBinPacking:
+EmptyLineAfterAccessModifier: Leave
+EmptyLineBeforeAccessModifier: Leave
+ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
-ForEachMacros: []
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks: Preserve
-IncludeCategories: []
-# "" matches none
-IncludeIsMainRegex: ""
-IncludeIsMainSourceRegex: ""
+IncludeCategories:
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '.*'
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: ''
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
 IndentCaseBlocks: true
 IndentCaseLabels: true
 IndentExternBlock: Indent
 IndentGotoLabels: false
 IndentPPDirectives: None
+IndentRequires: true
 IndentWidth: 2
 IndentWrappedFunctionNames: false
 InsertTrailingCommas: None
-# Java-specific
-#JavaImportGroups:
-# JavaScript-specific
-#JavaScriptQuotes:
-#JavaScriptWrapImports
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ""
-MacroBlockEnd: ""
-# Set to a large number to effectively disable
+LambdaBodyIndentation: Signature
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 100000
 NamespaceIndentation: None
-NamespaceMacros: []
-# Objective C-specific
-#ObjCBinPackProtocolList:
-#ObjCBlockIndentWidth:
-#ObjCBreakBeforeNestedBlockParam:
-#ObjCSpaceAfterProperty:
-#ObjCSpaceBeforeProtocolList
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PPIndentWidth: -1
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 1
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 1
 PenaltyBreakFirstLessLess: 1
+PenaltyBreakOpenParenthesis: 1
 PenaltyBreakString: 1
 PenaltyBreakTemplateDeclaration: 1
 PenaltyExcessCharacter: 1
+PenaltyIndentedWhitespace: 1
 PenaltyReturnTypeOnItsOwnLine: 1
-# Used as a fallback if alignment style can't be detected from code (DerivePointerAlignment: true)
 PointerAlignment: Right
-RawStringFormats: []
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
 ReflowComments: false
-SortIncludes: false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 0
+SortIncludes: Never
+SortJavaStaticImport: Before
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles: false
+SpacesInAngles: Leave
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum: 0
+  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Auto
-StatementMacros: []
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
 TabWidth: 2
-TypenameMacros: []
-# Default to LF if line endings can't be detected from the content (DeriveLineEnding).
 UseCRLF: false
 UseTab: Never
-WhitespaceSensitiveMacros: []
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 `
 	try := func(conf *paths.Path) bool {
 		if c, err := conf.ReadFile(); err != nil {


### PR DESCRIPTION
**Arduino Language Server**'s embedded **ClangFormat** configuration is designed to produce the standard Arduino sketch formatting style, as established by the [Arduino IDE 1.x](https://github.com/arduino/Arduino) formatter.

The configuration is consumed by several other projects. In order to provide all the consumers with a single canonical source and to locate the infrastructure and activity related to the maintenance of the file in a more appropriate repository, it is now hosted in a permanent location in the `arduino/tooling-project-assets` repository:

https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration

The following changes have been made to the source configuration:

- Move documentation comments to [a dedicated file in the upstream repository](https://github.com/arduino/tooling-project-assets/blob/main/other/clang-format-configuration/notes.md) (which is accessible via the URL in the comment at the top of the configuration)
- Make additional non-functional changes to the configuration format to facilitate maintenance
- Update to use the configuration API of [**ClangFormat** 14.0.0](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html)

This last item did result in some functional changes to the configuration which will result in minor differences in the formatter output.

These are actually reversions of unwanted differences from the Arduino IDE 1.x formatter output, which were unavoidable when using the 11.0.1 version of **ClangFormat** in use at the time of [the configuration's creation](https://github.com/arduino/arduino-language-server/commit/4083356ae32dee76c1d8b35537ba8ff2ecec4d09). The default output of the Arduino IDE 1.x formatter will continue to be considered the "gold standard" until Arduino IDE 2.x graduates from "pre-release" status, at which time its output (which is produced via the same configuration) will become the new standard.

The **Arduino Language Server** supports overriding the embedded default configuration with user provided configuration files. Those already using custom configurations will not be affected in any way (though they are encouraged to sync their configuration files from the source to bring them into compliance with the configuration API of the [clangd](https://clangd.llvm.org/) version 14.0.0 **Arduino Language Server** is intended to be used with).

See the documentation and commit history of the source file for details on the configuration changes:

https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration

---

Related: https://github.com/arduino/arduino-ide/pull/1285