### PR TITLE
Add support for macos arm64 build

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -201,12 +201,12 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Upload release files on Arduino downloads servers
+      #   uses: docker://plugins/s3
+      #   env:
+      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+      #     PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -201,12 +201,12 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      # - name: Upload release files on Arduino downloads servers
-      #   uses: docker://plugins/s3
-      #   env:
-      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-      #     PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Upload release files on Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -48,10 +48,121 @@ jobs:
           if-no-files-found: error
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
+  
+  notarize-macos:
+    name: Notarize ${{ matrix.artifact.name }}
+    runs-on: macos-latest
+    needs: create-release-artifacts
+    outputs:
+      checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
+      checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
+
+    env:
+      GON_CONFIG_PATH: gon.config.hcl
+
+    strategy:
+      matrix:
+        artifact:
+          - name: darwin_amd64
+            path: "macOS_64bit.tar.gz"
+          - name: darwin_arm64
+            path: "macOS_ARM64.tar.gz"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
+      - name: Import Code-Signing Certificates
+        env:
+          KEYCHAIN: "sign.keychain"
+          INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
+          KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+        run: |
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
+          security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security default-keychain -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security import \
+            "${{ env.INSTALLER_CERT_MAC_PATH }}" \
+            -k "${{ env.KEYCHAIN }}" \
+            -f pkcs12 \
+            -A \
+            -T "/usr/bin/codesign" \
+            -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
+
+      - name: Install gon for code signing and app notarization
+        run: |
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          unzip gon_macos.zip -d /usr/local/bin
+
+      - name: Write gon config to file
+        # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
+        run: |
+          cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
+          # See: https://github.com/mitchellh/gon#configuration-file
+          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"]
+          bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
+
+          sign {
+            application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
+          }
+
+          # Ask Gon for zip output to force notarization process to take place.
+          # The CI will ignore the zip output, using the signed binary only.
+          zip {
+            output_path = "unused.zip"
+          }
+          EOF
+
+      - name: Sign and notarize binary
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        run: |
+          gon "${{ env.GON_CONFIG_PATH }}"
+
+      - name: Re-package binary and output checksum
+        id: re-package
+        working-directory: ${{ env.DIST_DIR }}
+        # This step performs the following:
+        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        # 2. Recalculate package checksum
+        # 3. Output the new checksum to include in the nnnnnn-checksums.txt file
+        #    (it cannot be done there because of workflow job parallelization)
+        run: |
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
+          # so we need to add execution permission back until the action is made to do this.
+          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
+          tar -czvf "$PACKAGE_FILENAME" \
+          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
+          -C ../../ LICENSE.txt
+          CHECKSUM_LINE="$(shasum -a 256 $PACKAGE_FILENAME)"
+          echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
+          echo "::set-output name=checksum-${{ matrix.artifact.name }}::$CHECKSUM_LINE"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-release:
     runs-on: ubuntu-latest
-    needs: create-release-artifacts
+    needs: notarize-macos
 
     steps:
       - name: Download artifact
@@ -59,6 +170,16 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
+      
+      - name: Update checksum
+        run: |
+          declare -a checksum_lines=("${{ needs.notarize-macos.outputs.checksum-darwin_amd64 }}" "${{ needs.notarize-macos.outputs.checksum-darwin_arm64 }}")
+          for checksum_line in "${checksum_lines[@]}"
+          do
+            CHECKSUM=$(echo ${checksum_line} | cut -d " " -f 1)
+            PACKAGE_FILENAME=$(echo ${checksum_line} | cut -d " " -f 2)
+            perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM}  ${PACKAGE_FILENAME}/g;" ${{ env.DIST_DIR }}/*-checksums.txt
+          done
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -34,6 +34,7 @@ tasks:
       - task: Linux_ARMv7
       - task: Linux_ARM64
       - task: macOS_64bit
+      - task: macOS_ARM64
 
   Windows_32bit:
     desc: Builds Windows 32 bit binaries
@@ -250,4 +251,26 @@ tasks:
       # has the SDK 10.14 installed.
       CONTAINER_TAG: "{{.GO_VERSION}}-darwin-debian10"
       PACKAGE_PLATFORM: "macOS_64bit"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
+
+  macOS_ARM64:
+    desc: Builds Mac OS X ARM64 binaries
+    dir: "{{.DIST_DIR}}"
+    cmds:
+      - |
+        docker run -v `pwd`/..:/home/build -w /home/build \
+        -e CGO_ENABLED=1 \
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
+
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+
+    vars:
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_PLATFORM: "darwin/arm64"
+      CONTAINER_TAG: "{{.GO_VERSION}}-darwin-arm64-debian10"
+      PACKAGE_PLATFORM: "macOS_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**What is the current behavior?**
<!-- You can also link to an open issue here -->
A build for macos arm64 (M1) is not provided.

**What is the new behavior?**
<!-- if this is a feature change -->
The workflow `release-go-task` and `DistTasks` have been updated to handle the darwin_arm64 release and now match the corresponding ones present in the [tooling-project-assets](https://github.com/arduino/tooling-project-assets) repository.

**Other information**:
<!-- Any additional information that could help the review process -->
Here you can check the workflow run: https://github.com/MatteoPologruto/arduino-language-server/actions/runs/3053770326
And this is the release it created: https://github.com/MatteoPologruto/arduino-language-server/releases/tag/0.0.2

---
