### PR TITLE
Update ls release version automatically using ldflags

### DIFF
--- a/globals/globals.go
+++ b/globals/globals.go
@@ -1,0 +1,13 @@
+package globals
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/arduino/arduino-language-server/version"
+)
+
+var (
+	// VersionInfo contains all info injected during build
+	VersionInfo = version.NewInfo(filepath.Base(os.Args[0]))
+)

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/arduino/arduino-cli/executils"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/settings/v1"
+	"github.com/arduino/arduino-language-server/globals"
 	"github.com/arduino/arduino-language-server/sourcemapper"
 	"github.com/arduino/arduino-language-server/streams"
 	"github.com/arduino/go-paths-helper"
@@ -356,7 +357,7 @@ func (ls *INOLanguageServer) initializeReqFromIDE(ctx context.Context, logger js
 		},
 		ServerInfo: &lsp.InitializeResultServerInfo{
 			Name:    "arduino-language-server",
-			Version: "0.7.2",
+			Version: globals.VersionInfo.VersionString,
 		},
 	}
 	logger.Logf("initialization parameters: %s", string(lsp.EncodeMessage(resp)))

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -140,6 +140,7 @@ func NewINOLanguageServer(stdin io.Reader, stdout io.Writer, config *Config) *IN
 	}
 
 	logger.Logf("Initial board configuration: %s", ls.config.Fqbn)
+	logger.Logf("%s", globals.VersionInfo.String())
 	logger.Logf("Language server build path: %s", ls.buildPath)
 	logger.Logf("Language server build sketch root: %s", ls.buildSketchRoot)
 	logger.Logf("Language server FULL build path: %s", ls.fullBuildPath)

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import "fmt"
+
+var (
+	defaultVersionString = "0.0.0-git"
+	versionString        = ""
+	commit               = ""
+	date                 = ""
+)
+
+// Info is a struct that contains informations about the application
+type Info struct {
+	Application   string `json:"Application"`
+	VersionString string `json:"VersionString"`
+	Commit        string `json:"Commit"`
+	Date          string `json:"Date"`
+}
+
+// NewInfo returns a pointer to an updated Info struct
+func NewInfo(application string) *Info {
+	return &Info{
+		Application:   application,
+		VersionString: versionString,
+		Commit:        commit,
+		Date:          date,
+	}
+}
+
+func (i *Info) String() string {
+	return fmt.Sprintf("%[1]s Version: %[2]s Commit: %[3]s Date: %[4]s", i.Application, i.VersionString, i.Commit, i.Date)
+}
+
+//nolint:gochecknoinits
+func init() {
+	if versionString == "" {
+		versionString = defaultVersionString
+	}
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure enhancement

**What is the current behavior?**
<!-- You can also link to an open issue here -->
The Language Server's version ([ServerInfo](https://github.com/arduino/arduino-language-server/blob/main/ls/ls.go#L359)) has to be manually set to the new one during the release process. 

**What is the new behavior?**
<!-- if this is a feature change -->
The Language Server's version will be automatically updated using `ldflags`.  The version will also be printed in the log when a new Arduino Language Server is configured.
The changes were tested in this release: https://github.com/MatteoPologruto/arduino-language-server/releases/tag/99.99.99

---
