### PR TITLE
fix: ask clangd to not write .pch/.include cache on disk

### DIFF
--- a/ls/lsp_client_clangd.go
+++ b/ls/lsp_client_clangd.go
@@ -51,6 +51,7 @@ func newClangdLSPClient(logger jsonrpc.FunctionLogger, dataFolder *paths.Path, l
 	args := []string{
 		ls.config.ClangdPath.String(),
 		"-log=verbose",
+		"-pch-storage=memory",
 		fmt.Sprintf(`--compile-commands-dir=%s`, ls.buildPath),
 	}
 	if dataFolder != nil {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [X] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
.pch files are not created on disk, but in-memory as specified with `-pch-storage=memory` command line flag to `clangd`
Should finally fix #145 

**What is the current behavior?**
.pch files are created on temp directory and are not removed on exit.

**What is the new behavior?**
.pch files are no more created on temp directory.
