### PR TITLE
fix: do not use deprecated ubuntu-18.04 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             ExecutableSuffix: ''
             Exports: ''
           - os: macos-latest


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [X] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
Remove deprecated runner `ubuntu-18.04` from the test CI

**What is the current behavior?**

* **What is the new behavior?**

* **Other information**:
https://github.com/actions/runner-images/issues/6002