### PR TITLE
Fix panic in extractDataFolderFromArduinoCLI

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -1470,17 +1470,19 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 		}
 
 		type cmdRes struct {
-			Directories struct {
-				Data string `json:"data"`
-			} `json:"directories"`
+			Config struct {
+				Directories struct {
+					Data string `json:"data"`
+				} `json:"directories"`
+			} `json:"config"`
 		}
 		var res cmdRes
 		if err := json.Unmarshal(cmdOutput.Bytes(), &res); err != nil {
 			return nil, errors.Errorf("parsing arduino-cli output: %s", err)
 		}
 		// Return only the build path
-		logger.Logf("Arduino Data Dir -> %s", res.Directories.Data)
-		dataDir = res.Directories.Data
+		logger.Logf("Arduino Data Dir -> %s", res.Config.Directories.Data)
+		dataDir = res.Config.Directories.Data
 	}
 
 	dataDirPath := paths.New(dataDir)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix a panic when starting the server with a recent version of arduino-cli.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The server panics:

```
18:02:35.912080 \27[96mINIT --- : Arduino Data Dir -> \27[0m
18:02:35.912117 Panic: runtime error: invalid memory address or nil pointer dereference

goroutine 34 [running]:
runtime/debug.Stack()
	/usr/lib/go-1.21/src/runtime/debug/stack.go:24 +0x5e
github.com/arduino/arduino-language-server/streams.CatchAndLogPanic()
	/home/nicolas/Sources/arduino-language-server/streams/panics.go:29 +0x74
panic({0xa10660?, 0xffdd50?})
	/usr/lib/go-1.21/src/runtime/panic.go:920 +0x270
github.com/arduino/go-paths-helper.(*Path).Clone(...)
	/home/nicolas/go/pkg/mod/github.com/arduino/go-paths-helper@v1.11.0/paths.go:79
github.com/arduino/go-paths-helper.(*Path).Canonical(0xc000269b80?)
	/home/nicolas/go/pkg/mod/github.com/arduino/go-paths-helper@v1.11.0/paths.go:543 +0x19
github.com/arduino/arduino-language-server/ls.(*INOLanguageServer).extractDataFolderFromArduinoCLI(0xc000213680, {0xbc9b80, 0xc00019ed20})
	/home/nicolas/Sources/arduino-language-server/ls/ls.go:1487 +0xa25
github.com/arduino/arduino-language-server/ls.(*INOLanguageServer).initializeReqFromIDE.func1()
	/home/nicolas/Sources/arduino-language-server/ls/ls.go:214 +0x36a
created by github.com/arduino/arduino-language-server/ls.(*INOLanguageServer).initializeReqFromIDE in goroutine 21
	/home/nicolas/Sources/arduino-language-server/ls/ls.go:188 +0x205
```

* **What is the new behavior?**
<!-- if this is a feature change -->
The server runs nicely.

* **Other information**:

When using the latest arduino CLI (nightly-20240102 Commit: db53f81) the
return of `arduino-cli config dump` looks like:

	{
	  "config": {
	    "directories": {
	      "data": "/home/nicolas/.arduino15",
	      "downloads": "/home/nicolas/.arduino15/staging",
	      "user": "/home/nicolas/Arduino"
	    }
	  }
	}

<!-- Any additional information that could help the review process -->

Related to https://github.com/arduino/arduino-cli/pull/2407

---
