### PR TITLE
Limit parallel jobs to 1 / use in-memeory pch storage

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -77,6 +77,7 @@ type Config struct {
 	EnableLogging                   bool
 	SkipLibrariesDiscoveryOnRebuild bool
 	DisableRealTimeDiagnostics      bool
+	Jobs                            int
 }
 
 var yellow = color.New(color.FgHiYellow)

--- a/ls/lsp_client_clangd.go
+++ b/ls/lsp_client_clangd.go
@@ -51,6 +51,8 @@ func newClangdLSPClient(logger jsonrpc.FunctionLogger, dataFolder *paths.Path, l
 	args := []string{
 		ls.config.ClangdPath.String(),
 		"-log=verbose",
+		"-j", "1", // Limit parallel build jobs to 1
+		"--pch-storage=memory",
 		fmt.Sprintf(`--compile-commands-dir=%s`, ls.buildPath),
 	}
 	if dataFolder != nil {

--- a/ls/lsp_client_clangd.go
+++ b/ls/lsp_client_clangd.go
@@ -51,9 +51,16 @@ func newClangdLSPClient(logger jsonrpc.FunctionLogger, dataFolder *paths.Path, l
 	args := []string{
 		ls.config.ClangdPath.String(),
 		"-log=verbose",
-		"-j", "1", // Limit parallel build jobs to 1
 		"--pch-storage=memory",
 		fmt.Sprintf(`--compile-commands-dir=%s`, ls.buildPath),
+	}
+	if jobs := ls.config.Jobs; jobs == -1 {
+		// default: limit parallel build jobs to 1
+		args = append(args, "-j", "1")
+	} else if jobs == 0 {
+		// no args: clangd will max out the available cores
+	} else {
+		args = append(args, "-j", fmt.Sprintf("%d", jobs))
 	}
 	if dataFolder != nil {
 		args = append(args, fmt.Sprintf("-query-driver=%s", dataFolder.Join("packages", "**").Canonical()))

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 	noRealTimeDiagnostics := flag.Bool(
 		"no-real-time-diagnostics", false,
 		"Disable real time diagnostics")
+	jobs := flag.Int("jobs", -1, "Max number of parallel jobs. Default is 1. Use 0 to match the number of available CPU cores.")
 	flag.Parse()
 
 	if *loggingBasePath != "" {
@@ -127,6 +128,7 @@ func main() {
 		CliInstanceNumber:               *cliDaemonInstanceNumber,
 		SkipLibrariesDiscoveryOnRebuild: *skipLibrariesDiscoveryOnRebuild,
 		DisableRealTimeDiagnostics:      *noRealTimeDiagnostics,
+		Jobs:                            *jobs,
 	}
 
 	stdio := streams.NewReadWriteCloser(os.Stdin, os.Stdout)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [X] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
Limit the number of concurrent indexing jobs on `clangd`

**What is the current behavior?**
The number of concurrent jobs equals the number of available CPU cores. This may lead to unusable systems in some cases...

**What is the new behavior?**
Limit the jobs to 1 core (2 threads if hyperthreaded).

**Other information**:
Fix #176 (already confirmed by @facchinm)

