### PR TITLE
Fix error when attempting to determine Arduino data path from CLI output -- Needs review, not backwards compatible

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -1470,18 +1470,16 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 		}
 
 		type cmdRes struct {
-			Config struct {
-				Directories struct {
-					Data string `json:"data"`
-				} `json:"directories"`
-			} `json:"config"`
+			Directories struct {
+				Data string `json:"data"`
+			} `json:"directories"`
 		}
 		var res cmdRes
 		if err := json.Unmarshal(cmdOutput.Bytes(), &res); err != nil {
 			return nil, errors.Errorf("parsing arduino-cli output: %s", err)
 		}
 		// Return only the build path
-		dataDir = res.Config.Directories.Data
+		dataDir = res.Directories.Data
 	}
 
 	logger.Logf("Arduino Data Dir -> %s", dataDir)

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -1486,6 +1486,9 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 
 	logger.Logf("Arduino Data Dir -> %s", dataDir)
 	dataDirPath := paths.New(dataDir)
+	if dataDirPath == nil {
+		return nil, errors.Errorf("error creating path from %s", dataDir)
+	}
 	return dataDirPath.Canonical(), nil
 }
 

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -1451,7 +1451,6 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 		if err := json.Unmarshal([]byte(resp.JsonData), &dataDir); err != nil {
 			return nil, fmt.Errorf("error getting arduino data dir: %w", err)
 		}
-		logger.Logf("Arduino Data Dir -> %s", dataDir)
 	} else {
 		args := []string{
 			"--config-file", ls.config.CliConfigPath.String(),
@@ -1482,10 +1481,10 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 			return nil, errors.Errorf("parsing arduino-cli output: %s", err)
 		}
 		// Return only the build path
-		logger.Logf("Arduino Data Dir -> %s", res.Config.Directories.Data)
 		dataDir = res.Config.Directories.Data
 	}
 
+	logger.Logf("Arduino Data Dir -> %s", dataDir)
 	dataDirPath := paths.New(dataDir)
 	return dataDirPath.Canonical(), nil
 }


### PR DESCRIPTION
The arduino-language-server determines the Arduino data directory in one of two ways

1. If the `--cli-daemon-addr` and `--cli-daemon-instance` options are set, it uses gRPC to talk to a settings endpoint and extracts the `directories.data` key.

3. If the `--cli-config` option is set, it directly execs `arduino-cli` with arguments `config dump --format json` and attempts to parse the output as JSON into a pre-defined struct that assumes a particular structure.

With current (and perhaps previous?) versions of Arduino CLI (0.35.3), this second approach generates an error if the config file was generated with `arduino-cli config init` as the output does not match the code's expected format. 

file: `inols-err.log` (enabled with `--log` flag on arduino-language-server)
```
12:13:07.801837 [INIT --- : running: --config-file /Users/jason/Library/Arduino15/arduino-cli.yaml config dump --format json
12:13:07.809805 [INIT --- : Arduino Data Dir -> 
12:13:07.809908 textDocument/didOpen: locked (waiting clangd)
12:13:07.809929   textDocument/didOpen: clangd startup failed: quitting Language server
```

Because Go doesn't check for exact matches between target structs and source data, the `unmarshall` call does **not** return an error in this situation.

```go
		type cmdRes struct {
			Config struct {
				Directories struct {
					Data string `json:"data"`
				} `json:"directories"`
			} `json:"config"` // <--- THIS WRAPPER OBJECT DOESN'T EXIST IN THE JSON
		}
		var res cmdRes
		if err := json.Unmarshal(cmdOutput.Bytes(), &res); err != nil { // GO DOESN'T CARE THOUGH - NO ERROR!
			return nil, errors.Errorf("parsing arduino-cli output: %s", err)
		}
```

We end up with a zero-valued struct that happily returns an empty string as the data directory.

When we later turn this into a path with `dataDirPath := paths.New(dataDir)`, we end up with a nil pointer, as the paths constructor returns nil on empty string input.

file: `go-paths-helpe@v1.11/paths.go`
```go
func New(path ...string) *Path {
	if len(path) == 0 {
		return nil
	}
    // ...
```

The current version of the code fails to check for this condition.

Finally, when we pass this nil pointer along to clangd, it chokes, resulting in the vague error message about clangd startup failing.

```go
		// Retrieve data folder
		dataFolder, err := ls.extractDataFolderFromArduinoCLI(logger) // <- EQUAL TO NIL
		if err != nil {
			logger.Logf("error retrieving data folder from arduino-cli: %s", err) // <- REMEMBER, NO ERROR GENERATED!
			return
		}

		// Start clangd
		ls.Clangd = newClangdLSPClient(logger, dataFolder, ls) // <- BOOM.
```

The fix in this PR updates the code to work with the current output, **but it is not backward compatible!** 

I'll let someone else decide what to do next, but I wanted to make this patch (and explanation — pardon its length) available for anyone else running into this issue.

**Environment Detail**
- Arch: AARM64
- OS: MacOS Sonoma 14.3.1
- IDE: neovim
 neovim LSP config for arduino-language-server using `nvim-lspconfig`
```lua
    require('lspconfig').arduino_language_server.setup({
      on_attach = on_attach,
      capabilities = capabilities,
      cmd = {
        'arduino-language-server',
        '-cli-config',
        '/Users/jason/Library/Arduino15/arduino-cli.yaml',
        -- '-log' -- Warning: creates large log files in your project's root directory!
      },
    })
```

**Additional Information for Passerbys**

If you encounter this issue but are unfamiliar with Go, here's how to patch it quickly while the maintainers decide what to do with this PR.

Assuming you originally installed arduino-language-server with `go install github.com/arduino/arduino-language-server`, you can replace it with a locally patched version via:

```
# Clone this repository to your local computer (requires the git CLI)
git clone git@github.com:arduino/arduino-language-server
cd arduino-language-server
# Pull down this PR into a local branch named `patched`
git fetch origin pull/182/head:patched
# Checkout the new branch
git checkout patched
# Build and install this version -- replacing your existing copy
go install
```

