### PR TITLE
Bugfix: Arduino Data Dir nil dereference

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -1487,6 +1487,10 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 	}
 
 	dataDirPath := paths.New(dataDir)
+  if dataDirPath == nil {
+    return nil, nil
+  }
+
 	return dataDirPath.Canonical(), nil
 }
 

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -1487,9 +1487,9 @@ func (ls *INOLanguageServer) extractDataFolderFromArduinoCLI(logger jsonrpc.Func
 	}
 
 	dataDirPath := paths.New(dataDir)
-  if dataDirPath == nil {
-    return nil, nil
-  }
+	if dataDirPath == nil {
+		return nil, nil
+	}
 
 	return dataDirPath.Canonical(), nil
 }


### PR DESCRIPTION
# Bug
```go
func New(path ...string) *Path {
	if len(path) == 0 {
		return nil
	}
	if len(path) == 1 && path[0] == "" {
		return nil
	}
	res := &Path{path: path[0]}
	if len(path) > 1 {
		return res.Join(path[1:]...)
	}
	return res
}
```
```go
dataDirPath := paths.New(dataDir)
return dataDirPath.Canonical(), nil
```
When `dataDir` is an empty string, `paths.New(dataDir)` return `nil`, later de-referencing `nil`.

# Logs:
```
[ERROR][2024-06-13 18:04:12] .../vim/lsp/rpc.lua:734	"rpc"	"arduino-language-server"	"stderr"	"18:04:12.708708 \27[96mINIT --- : Arduino Data Dir -> \27[0m\n"
[ERROR][2024-06-13 18:04:12] .../vim/lsp/rpc.lua:734	"rpc"	"arduino-language-server"	"stderr"	"18:04:12.708773 Panic: runtime error: invalid memory address or nil pointer dereference\n\ngoroutine 34 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x65\ngithub.com/arduino/arduino-language-server/streams.CatchAndLogPanic()\n\t/home/build/streams/panics.go:29 +0x74\npanic({0xa725a0, 0x1066130})\n\t/usr/local/go/src/runtime/panic.go:844 +0x258\ngithub.com/arduino/go-paths-helper.(*Path).Clone(...)\n\t/go/pkg/mod/github.com/arduino/go-paths-helper@v1.7.0/paths.go:81\ngithub.com/arduino/go-paths-helper.(*Path).Canonical(0xc0002d1b78?)\n\t/go/pkg/mod/github.com/arduino/go-paths-helper@v1.7.0/paths.go:536 +0x1e\ngithub.com/arduino/arduino-language-server/ls.(*INOLanguageServer).extractDataFolderFromArduinoCLI(0xc0001e2300, {0xc45e20, 0xc00010e018})\n\t/home/build/ls/ls.go:1485 +0xa1f\ngithub.com/arduino/arduino-language-server/ls.(*INOLanguageServer).initializeReqFromIDE.func1()\n\t/home/build/ls/ls.go:215 +0x369\ncreated by github.com/arduino/arduino-language-server/ls.(*INOLanguageServer).initializeReqFromIDE\n\t/home/build/ls/ls.go:189 +0x20a\n\n18:04:12.708813 \27[92m                 textDocument/didOpen: \27[93mlocked (waiting clangd)\27[0m\27[0m\n18:04:12.708825 \27[92m                 textDocument/didOpen: clangd startup failed: quitting Language server\27[0m\n"
```

# Steps to reproduce
This needs work, as I am not entirely sure why this bug occurs on my system.
It seems like arduino-cli.yaml does not contain the dataFolder. Or at least `arduino-cli --config-file <file> config dump --format json` does not return the dataFolder.

# Extra information
I am using lvim together with mason. Mason installed arduino-language-server 0.7.6. Above logs describe the program.

Please feel free to leave a comment on how to improve this PR!

Kind regards,
Kraiwin