### PR TITLE
Fix container-related misconfigurations in release build tasks

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -131,11 +131,12 @@ tasks:
     desc: Builds Linux ARMv6 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
+        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
@@ -201,11 +202,12 @@ tasks:
     desc: Builds Mac OS X 64 bit binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
+        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
@@ -235,11 +237,12 @@ tasks:
     desc: Builds Mac OS X ARM64 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
+        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -172,7 +172,7 @@ tasks:
       #
       # Until there is a fix released we must use a recent gcc for Linux_ARMv6 build, so for this
       # build we select the debian10 based container.
-      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian10"
+      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian11"
       PACKAGE_PLATFORM: "Linux_ARMv6"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix.

## What is the current behavior?
<!-- You can also link to an open issue here -->

`DistTasks.yml` contains the tasks used to produce the release builds of the project for each of the host targets. The builds are produced in Docker containers.

Some regressions were introduced in these task at the time the project's Go version was bumped to 1.21.5 (which includes bumping the versions of the images used by the tasks: https://github.com/arduino/arduino-language-server/commit/1ccd378284b388b675b9b4d867186f3c00488697 / https://github.com/arduino/arduino-language-server/pull/174).

- Non-existent container tag referenced in the `Linux_ARMv6` task.
- Repository configuration incompatible for use in a container with modern Git versions due to "dubious ownership" (https://github.com/elastic/golang-crossbuild/issues/232).

These regressions would cause the failure of the ["Release" workflow](https://github.com/arduino/arduino-language-server/blob/main/.github/workflows/release-go-task.yml) run when it is triggered by a new release of the project.

## What is the new behavior?

### Use Debian 11 in `Linux_ARMv6` release build task

The `Linux_ARMv6` task must use a specific version of Debian in the container:

https://github.com/arduino/arduino-language-server/blob/5444eb5d420534cb4cdc2a137af597f6d5966829/DistTasks.yml#L147-L174

The Debian version is defined via the image tag. Previously, [Debian 10 was used](https://github.com/arduino/arduino-language-server/blob/5444eb5d420534cb4cdc2a137af597f6d5966829/DistTasks.yml#L175), and a tag of [the Go 1.18.3 image](https://github.com/elastic/golang-crossbuild/releases/tag/1.18.3) was available for this Debian version. However, the maintainers of the image did not produce a Debian 10 variant of [the Go 1.21.5 image](https://github.com/elastic/golang-crossbuild/releases/tag/v1.21.5), so the use of that tag caused the task to fail:

https://github.com/per1234/arduino-language-server/actions/runs/11772916519/job/32789011179#step:4:36

```text
Unable to find image 'docker.elastic.co/beats-dev/golang-crossbuild:1.21.5-armel-debian10' locally
docker: Error response from daemon: manifest for docker.elastic.co/beats-dev/golang-crossbuild:1.21.5-armel-debian10 not found: manifest unknown: manifest unknown.
See 'docker run --help'.
task: Failed to run task "dist:Linux_ARMv6": exit status 125
```

A Debian 11 variant of the image is available, and this version of Debian is also suitable for release builds. So the solution is to update the image tag referenced in the task to the Debian 11 tag.

### Configure repository for compatibility with modern Git versions in release build containers

As a security measure (see [CVE-2022-24765](https://nvd.nist.gov/vuln/detail/cve-2022-24765)), starting from 2.30.3 [Git requires the repository folder to be owned by the operating system user's account](https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9). Due to it having been [checked out outside the container](https://github.com/arduino/arduino-language-server/blob/5444eb5d420534cb4cdc2a137af597f6d5966829/.github/workflows/release-go-task.yml#L45-L48), the repository does not meet this requirement inside the container. An older version of Git was installed in the Go 1.18.3 Docker image, so this was not a problem before the bump, but a newer version is used in the Go 1.21.5 containers, which causes some tasks to fail (https://github.com/elastic/golang-crossbuild/issues/232):

https://github.com/per1234/arduino-language-server/actions/runs/11772976565/job/32789161736#step:4:148

```text
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
Error: failed building for linux/armv6: exit status 1
failed building for linux/armv6: exit status 1
task: Failed to run task "dist:Linux_ARMv6": exit status 1
```

https://github.com/per1234/arduino-language-server/actions/runs/11773011125/job/32789254088#step:4:146

```text
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
Error: failed building for darwin/amd64: exit status 1
failed building for darwin/amd64: exit status 1
task: Failed to run task "dist:macOS_64bit": exit status 1
```

https://github.com/per1234/arduino-language-server/actions/runs/11773011125/job/32789254192#step:4:161

```text
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
Error: failed building for darwin/arm64: exit status 1
failed building for darwin/arm64: exit status 1
task: Failed to run task "dist:macOS_ARM64": exit status 1
```

The solution is to configure Git to allow the use of the repository, despite the "dubious ownership" of its folder. This is done via [the `safe.directory` Git configuration variable](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory).

This approach is already in use in Arduino CLI's release build tasks: https://github.com/arduino/arduino-cli/commit/5a5ae94620478b602b4e75092d4e71e48b5c1862 / https://github.com/arduino/arduino-cli/pull/2103

## Other information

In order to facilitate the review of this pull request, I performed a demonstration release with the proposed changes in my fork:

https://github.com/per1234/arduino-language-server/actions/runs/11789922878

https://github.com/per1234/arduino-language-server/releases/tag/0.0.0-rc.12