### PR TITLE
github: Use IAM Roles to push files on AWS S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - main
   schedule:
     - cron: '0 4 * * MON-FRI' # run every weekday at 4AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
   workflow_dispatch:
@@ -68,6 +70,7 @@ jobs:
 
   publish:
     needs: build
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,14 @@ on:
       - main
 
 env:
+  # As defined by the Taskfile's PROJECT_NAME variable
+  PROJECT_NAME: arduino-language-server
   ARTIFACT_PREFIX: dist-
+  AWS_REGION: "us-east-1"
+  # The project's folder on Arduino's download server for uploading builds
+  AWS_PLUGIN_TARGET: /arduino-language-server/nightly/
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
 
 jobs:
 
@@ -65,20 +72,24 @@ jobs:
     needs: build
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+      id-token: write # This is required for requesting the JWT
     steps:
       - name: Download Workflow Artifact [GitHub Actions]
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ env.ARTIFACT_PREFIX }}*
           merge-multiple: true
-          path: build-artifacts
+          path: ${{ env.DIST_DIR }}
 
-      - name: Publish Nightly [S3]
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "build-artifacts/*"
-          PLUGIN_TARGET: "/arduino-language-server/nightly"
-          PLUGIN_STRIP_PREFIX: "build-artifacts/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload release files on Arduino downloads servers
+        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: build
 
 on:
   push:
-    branches:
-      - main
   schedule:
     - cron: '0 4 * * MON-FRI' # run every weekday at 4AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
   workflow_dispatch:
@@ -70,7 +68,6 @@ jobs:
 
   publish:
     needs: build
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -8,6 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-language-server/
+  AWS_REGION: "us-east-1"
   ARTIFACT_PREFIX: dist-
 
 on:
@@ -189,7 +190,11 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
+    environment: production
     needs: notarize-macos
+    permissions:
+      contents: write
+      id-token: write # This is required for requesting the JWT
 
     steps:
       - name: Download artifact
@@ -233,12 +238,12 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}


### PR DESCRIPTION
For security reasons long lived credentials are not considered secure.
To overcome this issue we can configure Github Workflows to use AWS OpenID Connect instead:
For further details: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

Tested:
- [x] Release: https://github.com/arduino/arduino-language-server/actions/runs/12298678391/job/34322886420
- [x] Removed old aws acces_key and secret_key
- [x] Nightly release: https://github.com/arduino/arduino-language-server/actions/runs/12298848380/job/34323303089