### PR TITLE
Fix for the lsp crashing upon a textDocument/definition on untracked files

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -88,10 +88,8 @@ type Config struct {
 }
 
 var extToFileType = map[string]string{
-	".ino": "arduino",
-	".cpp": "cpp",
 	".h":   "cpp",
-	".c":   "c",
+	".hpp": "cpp",
 }
 
 var yellow = color.New(color.FgHiYellow)
@@ -1639,6 +1637,16 @@ type UnknownURIError struct {
 	URI lsp.DocumentURI
 }
 
+// UnknownFileExtensionError when a file extension isn't recognized
+// and a file with it has to be opened.
+type UnknownFileExtensionError struct {
+	extension string
+}
+
 func (e *UnknownURIError) Error() string {
 	return "Document is not available: " + e.URI.String()
+}
+
+func (e *UnknownFileExtensionError) Error() string {
+	return "Unknown file extension " + e.extension
 }

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -68,10 +68,6 @@ type INOLanguageServer struct {
 	sketchRebuilder           *sketchRebuilder
 }
 
-type TranslationOpts struct {
-	loadRelToIde bool
-}
-
 // Config describes the language server configuration.
 type Config struct {
 	Fqbn                            string
@@ -90,6 +86,10 @@ type Config struct {
 var extToFileType = map[string]string{
 	".h":   "cpp",
 	".hpp": "cpp",
+}
+
+type translationOpts struct {
+	loadRelToIde bool
 }
 
 var yellow = color.New(color.FgHiYellow)
@@ -612,7 +612,7 @@ func (ls *INOLanguageServer) textDocumentDefinitionReqFromIDE(ctx context.Contex
 
 	var ideLocations []lsp.Location
 	if clangLocations != nil {
-		opts := TranslationOpts{loadRelToIde: true}
+		opts := translationOpts{loadRelToIde: true}
 		ideLocations, err = ls.clang2IdeLocationsArray2(logger, clangLocations, &opts)
 		if err != nil {
 			logger.Logf("Error: %v", err)

--- a/ls/ls_clang_to_ide.go
+++ b/ls/ls_clang_to_ide.go
@@ -36,7 +36,7 @@ func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI(logger jsonrpc.Functio
 // - The IDE DocumentURI and Range
 // - a boolean that is true if the clang range is in the preprocessed area of the sketch
 // - an error
-func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI2(logger jsonrpc.FunctionLogger, clangURI lsp.DocumentURI, clangRange lsp.Range, opts *TranslationOpts) (lsp.DocumentURI, lsp.Range, bool, error) {
+func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI2(logger jsonrpc.FunctionLogger, clangURI lsp.DocumentURI, clangRange lsp.Range, opts *translationOpts) (lsp.DocumentURI, lsp.Range, bool, error) {
 	// Sketchbook/Sketch/Sketch.ino      <-> build-path/sketch/Sketch.ino.cpp
 	// Sketchbook/Sketch/AnotherTab.ino  <-> build-path/sketch/Sketch.ino.cpp  (different section from above)
 	if ls.clangURIRefersToIno(clangURI) {
@@ -320,7 +320,7 @@ func (ls *INOLanguageServer) cland2IdeTextEdits(logger jsonrpc.FunctionLogger, c
 func (ls *INOLanguageServer) clang2IdeLocationsArray(logger jsonrpc.FunctionLogger, clangLocations []lsp.Location) ([]lsp.Location, error) {
 	return ls.clang2IdeLocationsArray2(logger, clangLocations, nil)
 }
-func (ls *INOLanguageServer) clang2IdeLocationsArray2(logger jsonrpc.FunctionLogger, clangLocations []lsp.Location, opts *TranslationOpts) ([]lsp.Location, error) {
+func (ls *INOLanguageServer) clang2IdeLocationsArray2(logger jsonrpc.FunctionLogger, clangLocations []lsp.Location, opts *translationOpts) ([]lsp.Location, error) {
 	ideLocations := []lsp.Location{}
 	for _, clangLocation := range clangLocations {
 		ideLocation, inPreprocessed, err := ls.clang2IdeLocation2(logger, clangLocation, opts)
@@ -340,7 +340,7 @@ func (ls *INOLanguageServer) clang2IdeLocationsArray2(logger jsonrpc.FunctionLog
 func (ls *INOLanguageServer) clang2IdeLocation(logger jsonrpc.FunctionLogger, clangLocation lsp.Location) (lsp.Location, bool, error) {
 	return ls.clang2IdeLocation2(logger, clangLocation, nil)
 }
-func (ls *INOLanguageServer) clang2IdeLocation2(logger jsonrpc.FunctionLogger, clangLocation lsp.Location, opts *TranslationOpts) (lsp.Location, bool, error) {
+func (ls *INOLanguageServer) clang2IdeLocation2(logger jsonrpc.FunctionLogger, clangLocation lsp.Location, opts *translationOpts) (lsp.Location, bool, error) {
 	ideURI, ideRange, inPreprocessed, err := ls.clang2IdeRangeAndDocumentURI2(logger, clangLocation.URI, clangLocation.Range, opts)
 	return lsp.Location{
 		URI:   ideURI,

--- a/ls/ls_ide_to_clang.go
+++ b/ls/ls_ide_to_clang.go
@@ -25,8 +25,7 @@ import (
 	"go.bug.st/lsp/jsonrpc"
 )
 
-func getFileType(filename string) string {
-	ext := filepath.Ext(filename)
+func getFileType(ext string) string {
 	if fileType, ok := extToFileType[ext]; ok {
 		return fileType
 	}
@@ -37,11 +36,12 @@ func (ls *INOLanguageServer) idePathToIdeURI(logger jsonrpc.FunctionLogger, inoP
 }
 
 func makeTextDocumentItem(logger jsonrpc.FunctionLogger, path string) (lsp.TextDocumentItem, bool, error) {
+	ext := filepath.Ext(path)
 	filetype := getFileType(path)
-	if filetype == "unknown" {
-		return lsp.TextDocumentItem{}, false, nil
-	}
 	uri := lsp.NewDocumentURI(path)
+	if filetype == "unknown" {
+		return lsp.TextDocumentItem{URI: uri, LanguageID: filetype}, false, &UnknownFileExtensionError{ext}
+	}
 	languageId := filetype
 	version := 0
 

--- a/ls/ls_ide_to_clang.go
+++ b/ls/ls_ide_to_clang.go
@@ -42,7 +42,7 @@ func makeTextDocumentItem(logger jsonrpc.FunctionLogger, path string) (lsp.TextD
 	if filetype == "unknown" {
 		return lsp.TextDocumentItem{URI: uri, LanguageID: filetype}, false, &UnknownFileExtensionError{ext}
 	}
-	languageId := filetype
+	languageID := filetype
 	version := 0
 
 	text, err := os.ReadFile(path)
@@ -50,10 +50,10 @@ func makeTextDocumentItem(logger jsonrpc.FunctionLogger, path string) (lsp.TextD
 		logger.Logf("Could not read file: %v", err)
 		return lsp.TextDocumentItem{}, false, err
 	}
-	return lsp.TextDocumentItem{URI: uri, LanguageID: languageId, Version: version, Text: string(text)}, true, nil
+	return lsp.TextDocumentItem{URI: uri, LanguageID: languageID, Version: version, Text: string(text)}, true, nil
 
 }
-func (ls *INOLanguageServer) idePathToIdeURI2(logger jsonrpc.FunctionLogger, inoPath string, opts *TranslationOpts) (lsp.DocumentURI, error) {
+func (ls *INOLanguageServer) idePathToIdeURI2(logger jsonrpc.FunctionLogger, inoPath string) (lsp.DocumentURI, error) {
 	if inoPath == sourcemapper.NotIno.File {
 		return sourcemapper.NotInoURI, nil
 	}


### PR DESCRIPTION



- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Fixes the textDocument/definition crash on untracked files, in other words files that haven't been opened yet.

- **What is the current behavior?**
This problem is described here:
https://github.com/arduino/arduino-language-server/issues/159
A thing to note is that this only happens with files relative to the sketch root. Meaning if they are for example in a library folder somewhere and they get found by clangd the file just gets opened with the clangd path and this crash doesn't occur, because the check for whether they are tracked just never happens.

* **What is the new behavior?**
The lsp starts tracking the new file and opens it successfully. A thing to note is that this is currently true only for certain files (those with extensions .h and .hpp, set in the extToFileType map). For all other files with different extensions, the lsp returns an unknown file extension error and closes. 
To be honest, I am not entirely certain about this behavior so I am also looking for a second opinion. On one hand the only real files that would be included are probably .h and .hpp. On the other hand closing the entire lsp just because of this doesn't really make sense to me. It could also make sense to have a list of allowed extensions that's passed to the lsp via an argument. 

Also, I kind of want to write a test for this, but I am not even sure where to put it.
