### PR TITLE
Fix crash upon a go to definition request on untracked files

### DIFF
--- a/ls/ls_clang_to_ide.go
+++ b/ls/ls_clang_to_ide.go
@@ -27,12 +27,16 @@ func (ls *INOLanguageServer) clangURIRefersToIno(clangURI lsp.DocumentURI) bool 
 	return clangURI.AsPath().EquivalentTo(ls.buildSketchCpp)
 }
 
+func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI(logger jsonrpc.FunctionLogger, clangURI lsp.DocumentURI, clangRange lsp.Range) (lsp.DocumentURI, lsp.Range, bool, error) {
+	return ls.clang2IdeRangeAndDocumentURI2(logger, clangURI, clangRange, nil)
+}
+
 // Convert Range and DocumentURI from Clang to IDE.
 // Returns:
 // - The IDE DocumentURI and Range
 // - a boolean that is true if the clang range is in the preprocessed area of the sketch
 // - an error
-func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI(logger jsonrpc.FunctionLogger, clangURI lsp.DocumentURI, clangRange lsp.Range) (lsp.DocumentURI, lsp.Range, bool, error) {
+func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI2(logger jsonrpc.FunctionLogger, clangURI lsp.DocumentURI, clangRange lsp.Range, opts *translationOpts) (lsp.DocumentURI, lsp.Range, bool, error) {
 	// Sketchbook/Sketch/Sketch.ino      <-> build-path/sketch/Sketch.ino.cpp
 	// Sketchbook/Sketch/AnotherTab.ino  <-> build-path/sketch/Sketch.ino.cpp  (different section from above)
 	if ls.clangURIRefersToIno(clangURI) {
@@ -80,7 +84,25 @@ func (ls *INOLanguageServer) clang2IdeRangeAndDocumentURI(logger jsonrpc.Functio
 		return lsp.NilURI, lsp.NilRange, false, err
 	}
 	idePath := ls.sketchRoot.JoinPath(rel).String()
-	ideURI, err := ls.idePathToIdeURI(logger, idePath)
+
+	var ideURI lsp.DocumentURI
+	if opts == nil || !opts.loadRelToIde {
+		ideURI, err = ls.idePathToIdeURI(logger, idePath)
+	} else {
+		doc, ok := ls.trackedIdeDocs[idePath]
+		if !ok {
+			var shouldOpen bool
+			doc, shouldOpen, err = makeTextDocumentItem(logger, idePath)
+			if err != nil {
+				logger.Logf("ERROR: could not open '%s': %s", idePath, err)
+			}
+			if shouldOpen {
+				ls.implTextDocumentDidOpenNotifFromIDE(logger, doc)
+			}
+
+		}
+		ideURI = doc.URI
+	}
 	if ideRange.End.Line > 0 {
 		ideRange.End.Line--
 	}
@@ -296,9 +318,12 @@ func (ls *INOLanguageServer) cland2IdeTextEdits(logger jsonrpc.FunctionLogger, c
 }
 
 func (ls *INOLanguageServer) clang2IdeLocationsArray(logger jsonrpc.FunctionLogger, clangLocations []lsp.Location) ([]lsp.Location, error) {
+	return ls.clang2IdeLocationsArray2(logger, clangLocations, nil)
+}
+func (ls *INOLanguageServer) clang2IdeLocationsArray2(logger jsonrpc.FunctionLogger, clangLocations []lsp.Location, opts *translationOpts) ([]lsp.Location, error) {
 	ideLocations := []lsp.Location{}
 	for _, clangLocation := range clangLocations {
-		ideLocation, inPreprocessed, err := ls.clang2IdeLocation(logger, clangLocation)
+		ideLocation, inPreprocessed, err := ls.clang2IdeLocation2(logger, clangLocation, opts)
 		if err != nil {
 			logger.Logf("ERROR converting location %s: %s", clangLocation, err)
 			return nil, err
@@ -313,7 +338,10 @@ func (ls *INOLanguageServer) clang2IdeLocationsArray(logger jsonrpc.FunctionLogg
 }
 
 func (ls *INOLanguageServer) clang2IdeLocation(logger jsonrpc.FunctionLogger, clangLocation lsp.Location) (lsp.Location, bool, error) {
-	ideURI, ideRange, inPreprocessed, err := ls.clang2IdeRangeAndDocumentURI(logger, clangLocation.URI, clangLocation.Range)
+	return ls.clang2IdeLocation2(logger, clangLocation, nil)
+}
+func (ls *INOLanguageServer) clang2IdeLocation2(logger jsonrpc.FunctionLogger, clangLocation lsp.Location, opts *translationOpts) (lsp.Location, bool, error) {
+	ideURI, ideRange, inPreprocessed, err := ls.clang2IdeRangeAndDocumentURI2(logger, clangLocation.URI, clangLocation.Range, opts)
 	return lsp.Location{
 		URI:   ideURI,
 		Range: ideRange,


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Fixes the textDocument/definition crash on untracked files, in other words files that haven't been opened yet.

- **What is the current behavior?**
This problem is described here:
https://github.com/arduino/arduino-language-server/issues/159
A thing to note is that this only happens with files relative to the sketch root. Meaning if they are for example in a library folder somewhere and they get found by clangd the file just gets opened with the clangd path and this crash doesn't occur, because the check for whether they are tracked just never happens.

* **What is the new behavior?**
The lsp starts tracking the new file and opens it successfully. A thing to note is that this is currently true only for certain files (those with extensions .h and .hpp, set in the extToFileType map). For all other files with different extensions, the lsp returns an unknown file extension error and closes.
To be honest, I am not entirely certain about this behavior so I am also looking for a second opinion. On one hand the only real files that would be included are probably .h and .hpp. On the other hand closing the entire lsp just because of this doesn't really make sense to me. It could also make sense to have a list of allowed extensions that's passed to the lsp via an argument.

Also, I kind of want to write a test for this, but I am not even sure where to put it 
(accidentally closed previous pr)

