### PR TITLE
fix a panic causing a crash when clangd sends workspaceSemanticTokensRefresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace (
-	go.bug.st/lsp v0.1.3 => ../go-lsp
-)

--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace (
+	go.bug.st v0.1.3 => ../go-lsp
+)

--- a/go.mod
+++ b/go.mod
@@ -34,5 +34,5 @@ require (
 )
 
 replace (
-	go.bug.st v0.1.3 => ../go-lsp
+	go.bug.st/lsp v0.1.3 => ../go-lsp
 )

--- a/ls/lsp_client_clangd.go
+++ b/ls/lsp_client_clangd.go
@@ -168,6 +168,10 @@ func (client *clangdLSPClient) WorkspaceCodeLensRefresh(context.Context, jsonrpc
 	panic("unimplemented")
 }
 
+func (client *clangdLSPClient) WorkspaceSemanticTokensRefresh(context.Context, jsonrpc.FunctionLogger) *jsonrpc.ResponseError {
+	return nil
+}
+
 // Progress sends a Progress notification
 func (client *clangdLSPClient) Progress(logger jsonrpc.FunctionLogger, progress *lsp.ProgressParams) {
 	client.ls.progressNotifFromClangd(logger, progress)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
adds a client handler for `workspace/semanticTokens/refresh`  in `lsp_client_clangd.go`.

- **What is the current behavior?**
When clangd sends `workspace/semanticTokens/refresh`, it causes a panic. This causes the language server to crash on every restart. A workaround has been to disable semantic tokens in your editor, but this fix should prevent the need to do so.
> 21:11:04.196586 IDE     LS <-- Clangd REQU workspace/semanticTokens/refresh 1
> 21:11:04.196684 Panic: unimplemented request: workspace/semanticTokens/refresh


* **What is the new behavior?**
refresh request comes in and goes out, without causing a panic and crashing the language server.
> 21:19:11.867890 IDE     LS <-- Clangd REQU workspace/semanticTokens/refresh 1
> 21:19:11.867912 IDE     LS --> Clangd RESP workspace/semanticTokens/refresh 1

* **Other information**:
depends on [bugst/go-lsp#10](https://github.com/bugst/go-lsp/pull/10) to be approved and merged first. The module version should then be bumped up before merge.
---

Fixes #125 Fixes #155 
