### PR TITLE
Fix non-working clangd quick-fixes (convert applyFix commands into inline code actions)

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -843,7 +843,7 @@ func (ls *INOLanguageServer) textDocumentCodeActionReqFromIDE(ctx context.Contex
 
 	// TODO: Create a function for this one?
 	ideCommandsOrCodeActions := []lsp.CommandOrCodeAction{}
-	if clangCommandsOrCodeActions != nil {
+	if clangCommandsOrCodeActions == nil {
 		return ideCommandsOrCodeActions, nil
 	}
 	logger.Logf("    <-- codeAction(%d elements)", len(clangCommandsOrCodeActions))
@@ -852,11 +852,24 @@ func (ls *INOLanguageServer) textDocumentCodeActionReqFromIDE(ctx context.Contex
 		switch i := clangItem.Get().(type) {
 		case lsp.Command:
 			logger.Logf("        > Command: %s", i.Title)
-			ideCommand := ls.clang2IdeCommand(logger, i)
-			if ideCommand == nil {
-				continue // Skip unsupported command
+			if i.Command == "clangd.applyFix" && len(i.Arguments) > 0 {
+				var clangWorkspaceEdit lsp.WorkspaceEdit
+				if err := json.Unmarshal(i.Arguments[0], &clangWorkspaceEdit); err != nil {
+					logger.Logf("ERROR: could not unmarshal clangd.applyFix arguments: %v", err)
+					continue
+				}
+				ideItem.Set(lsp.CodeAction{
+					Title: i.Title,
+					Kind:  lsp.CodeActionKindQuickFix,
+					Edit:  ls.cpp2inoWorkspaceEdit(logger, &clangWorkspaceEdit),
+				})
+			} else {
+				ideCommand := ls.clang2IdeCommand(logger, i)
+				if ideCommand == nil {
+					continue // Skip unsupported command
+				}
+				ideItem.Set(*ideCommand)
 			}
-			ideItem.Set(*ideCommand)
 		case lsp.CodeAction:
 			logger.Logf("        > CodeAction: %s", i.Title)
 			ideCodeAction := ls.clang2IdeCodeAction(logger, i, ideURI)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**

Bug fix.

- **What is the current behavior?**

The `textDocument/codeAction` handler always returns an empty list `[]` to the IDE, so no code actions or quick-fixes ever reach it. This is caused by an inverted guard in `textDocumentCodeActionReqFromIDE`: `if clangCommandsOrCodeActions != nil { return <empty> }`. Whenever clangd actually returns code actions (non-nil), the handler returns the freshly-initialized empty slice and the conversion loop is never reached; when clangd returns nothing, the loop runs over a nil slice and also yields `[]`. Either way the response is `[]`.

On top of that, even once items are processed, clangd delivers its quick-fixes as `clangd.applyFix` *commands* (with the `WorkspaceEdit` as an argument). `clang2IdeCommand` only recognizes `clangd.applyTweak` and returns `nil` for `clangd.applyFix`, so those commands are dropped, and the `workspace/executeCommand` round-trip they would require is unimplemented anyway.

* **What is the new behavior?**

The inverted nil-check is corrected (`== nil`) so code actions are actually converted and returned to the IDE instead of an empty list.

Additionally, `clangd.applyFix` commands are converted into native LSP `CodeAction` quick-fixes: the command's `WorkspaceEdit` argument is unmarshaled, mapped from the clangd (`.cpp`) document back to the IDE (`.ino`) document via `cpp2inoWorkspaceEdit`, and returned as a `CodeActionKindQuickFix` with the edit inlined. The IDE can then apply the fix directly, with no `executeCommand` round-trip needed.
