### PR TITLE
fix: handle unsupported inlay hint requests

### DIFF
--- a/ls/lsp_server_ide.go
+++ b/ls/lsp_server_ide.go
@@ -38,6 +38,9 @@ func NewIDELSPServer(logger jsonrpc.FunctionLogger, in io.Reader, out io.Writer,
 	}
 	server.conn = lsp.NewServer(in, out, server)
 	server.conn.RegisterCustomNotification("ino/didCompleteBuild", server.ArduinoBuildCompleted)
+	server.conn.RegisterCustomRequest("textDocument/inlayHint", func(context.Context, jsonrpc.FunctionLogger, json.RawMessage) (interface{}, *jsonrpc.ResponseError) {
+		return nil, nil
+	})
 	server.conn.SetLogger(&Logger{
 		IncomingPrefix: "IDE --> LS",
 		OutgoingPrefix: "IDE <-- LS",

--- a/ls/lsp_server_ide_test.go
+++ b/ls/lsp_server_ide_test.go
@@ -1,0 +1,36 @@
+// This file is part of arduino-language-server.
+//
+// Copyright 2026 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU Affero General Public License version 3,
+// which covers the main part of arduino-language-server.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/agpl-3.0.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package ls
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInlayHintRequestReturnsNull(t *testing.T) {
+	request := `{"jsonrpc":"2.0","id":1,"method":"textDocument/inlayHint","params":{"textDocument":{"uri":"file:///sketch.ino"},"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}}}}`
+	input := fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(request), request)
+	output := &bytes.Buffer{}
+
+	server := NewIDELSPServer(nil, strings.NewReader(input), output, nil)
+	server.Run()
+
+	require.Contains(t, output.String(), `{"jsonrpc":"2.0","id":1,"result":null}`)
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-language-server/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://github.com/arduino/arduino-language-server#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**

Bug fix.

- **What is the current behavior?**

Fixes #225. An LSP client sending `textDocument/inlayHint` causes the request dispatcher to panic because the method is not implemented by the bundled LSP library.

* **What is the new behavior?**

The IDE-facing server registers the request explicitly and returns the LSP-valid `null` result, so unsupported inlay hints no longer terminate the server. The regression test sends a framed JSON-RPC request through the real server connection and checks the response.

* **Other information**:

Tests:

* `go test ./ls -run TestInlayHintRequestReturnsNull -v`
* `go test ./...`
* `go vet ./...`
* `golint -min_confidence 0.8 -set_exit_status ./...`
* `go fix ./...` — no changes
* `go mod tidy` — no changes
* `git diff --check`
